### PR TITLE
[2팀 유윤우] Chapter 1-3. 프레임워크 없이 SPA 만들기

### DIFF
--- a/packages/app/404.html
+++ b/packages/app/404.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>상품 쇼핑몰</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License
+      // https://github.com/rafgraph/spa-github-pages
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. https://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // https://www.foo.tld/?/one/two&a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set pathSegmentsToKeep to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?/one/two&a=b~and~c=d#qwe
+      // Otherwise, leave pathSegmentsToKeep as 0.
+      console.log("404");
+      var pathSegmentsToKeep = 1;
+
+      var l = window.location;
+      l.replace(
+        l.protocol +
+          "//" +
+          l.hostname +
+          (l.port ? ":" + l.port : "") +
+          l.pathname
+            .split("/")
+            .slice(0, 1 + pathSegmentsToKeep)
+            .join("/") +
+          "/?/" +
+          l.pathname.slice(1).split("/").slice(pathSegmentsToKeep).join("/").replace(/&/g, "~and~") +
+          (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+          l.hash,
+      );
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -8,9 +8,9 @@ export const createObserver = () => {
     listeners.add(fn);
   };
 
-  const unsubscribe = (fn: Listener) => {
-    listeners.delete(fn);
-  };
+  // const unsubscribe = (fn: Listener) => {
+  //   listeners.delete(fn);
+  // };
 
   const notify = () => listeners.forEach((listener) => listener());
 

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -6,11 +6,12 @@ export const createObserver = () => {
   // useSyncExternalStore 에서 활용할 수 있도록 subscribe 함수를 수정합니다.
   const subscribe = (fn: Listener) => {
     listeners.add(fn);
-  };
 
-  // const unsubscribe = (fn: Listener) => {
-  //   listeners.delete(fn);
-  // };
+    // unsubscribe 함수를 반환
+    return () => {
+      listeners.delete(fn);
+    };
+  };
 
   const notify = () => listeners.forEach((listener) => listener());
 

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,3 +1,38 @@
 export const deepEquals = (a: unknown, b: unknown) => {
-  return a === b;
+  if (a === b) {
+    return true;
+  }
+
+  if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) {
+    return false;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEquals(a[i], b[i])) return false;
+    }
+
+    return true;
+  }
+
+  if (typeof a === "object" && typeof b === "object") {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+
+    if (keysA.length !== keysB.length) {
+      return false;
+    }
+
+    for (const key of keysA) {
+      if (!Object.hasOwn(b, key) || !deepEquals(a[key as keyof typeof a], b[key as keyof typeof b])) return false;
+    }
+
+    return true;
+  }
+
+  return true;
 };

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,12 +1,15 @@
 export const deepEquals = (a: unknown, b: unknown) => {
-  if (a === b) {
+  // 1. 값이 같으면 바로 true 반환 참조 타입의 경우 주소 비교
+  if (Object.is(a, b)) {
     return true;
   }
 
-  if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) {
-    return false;
+  // 2. 원시 값 처리
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) {
+    return Object.is(a, b);
   }
 
+  // 3. 배열 깊은비교 재귀
   if (Array.isArray(a) && Array.isArray(b)) {
     if (a.length !== b.length) {
       return false;
@@ -19,19 +22,16 @@ export const deepEquals = (a: unknown, b: unknown) => {
     return true;
   }
 
-  if (typeof a === "object" && typeof b === "object") {
-    const keysA = Object.keys(a);
-    const keysB = Object.keys(b);
+  // 4. 객체 깊은비교 재귀
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
 
-    if (keysA.length !== keysB.length) {
-      return false;
-    }
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
 
-    for (const key of keysA) {
-      if (!Object.hasOwn(b, key) || !deepEquals(a[key as keyof typeof a], b[key as keyof typeof b])) return false;
-    }
-
-    return true;
+  for (const key of keysA) {
+    if (!deepEquals(a[key as keyof typeof a], b[key as keyof typeof b])) return false;
   }
 
   return true;

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,3 +1,23 @@
 export const shallowEquals = (a: unknown, b: unknown) => {
-  return a === b;
+  if (a === b) {
+    return true;
+  }
+
+  if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) {
+    return false;
+  }
+
+  const keysA = Object.keys(a) as (keyof typeof a)[];
+  const keysB = Object.keys(b) as (keyof typeof b)[];
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  for (const key of keysA) {
+    if (!Object.hasOwn(b, key) || a[key] !== b[key]) {
+      return false;
+    }
+  }
+  return true;
 };

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,23 +1,36 @@
 export const shallowEquals = (a: unknown, b: unknown) => {
-  if (a === b) {
+  // 1. 값이 같으면 바로 true 반환 참조 타입의 경우 주소 비교
+  if (Object.is(a, b)) {
     return true;
   }
 
-  if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) {
-    return false;
+  // 2. 원시 값 처리
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) {
+    return Object.is(a, b);
   }
 
-  const keysA = Object.keys(a) as (keyof typeof a)[];
-  const keysB = Object.keys(b) as (keyof typeof b)[];
+  // 3. 배열 얕은비교
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) {
+      return false;
+    }
+
+    return a.every((value, index) => Object.is(value, b[index]));
+  }
+
+  // 4. 객체 얕은비교
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
 
   if (keysA.length !== keysB.length) {
     return false;
   }
 
   for (const key of keysA) {
-    if (!Object.hasOwn(b, key) || a[key] !== b[key]) {
+    if (!Object.is(a[key as keyof typeof a], b[key as keyof typeof b])) {
       return false;
     }
   }
+
   return true;
 };

--- a/packages/lib/src/hocs/deepMemo.ts
+++ b/packages/lib/src/hocs/deepMemo.ts
@@ -1,5 +1,7 @@
 import type { FunctionComponent } from "react";
+import { memo } from "./memo";
+import { deepEquals } from "../equals";
 
 export function deepMemo<P extends object>(Component: FunctionComponent<P>) {
-  return Component;
+  return memo(Component, deepEquals);
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -1,7 +1,26 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { type FunctionComponent } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "../hooks";
 
 export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
-  return Component;
+  const MemoizedComponent = (props: P) => {
+    const prevPropsRef = useRef<P | null>(null);
+    const prevComponentRef = useRef<unknown>(null);
+
+    // 이전 props와 현재 props 비교
+    if (prevPropsRef.current && equals(prevPropsRef.current, props)) {
+      // props가 같으면 이전 렌더 결과를 반환 (메모이제이션)
+      return prevComponentRef.current;
+    }
+
+    // props가 다르면 새로운 렌더링
+    const result = Component(props);
+
+    prevPropsRef.current = props;
+    prevComponentRef.current = result;
+
+    return result;
+  };
+
+  return MemoizedComponent;
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { type FunctionComponent } from "react";
 import { shallowEquals } from "../equals";
 

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -1,6 +1,6 @@
 import type { AnyFunction } from "../types";
-import { useCallback } from "./useCallback";
-import { useRef } from "./useRef";
+// import { useCallback } from "./useCallback";
+// import { useRef } from "./useRef";
 
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
   return fn;

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -1,7 +1,15 @@
 import type { AnyFunction } from "../types";
-// import { useCallback } from "./useCallback";
-// import { useRef } from "./useRef";
+import { useCallback } from "./useCallback";
+import { useRef } from "./useRef";
 
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
-  return fn;
+  const fnRef = useRef<T>(fn);
+
+  // 렌더링 시점에 매번 업데이트
+  fnRef.current = fn;
+
+  const memoizedCallback = useCallback(() => fnRef.current(), []);
+
+  // 항상 같은 참조를 반환하되, 내부에서 최신 fn을 호출
+  return memoizedCallback as T;
 };

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -8,7 +8,7 @@ export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
   // 렌더링 시점에 매번 업데이트
   fnRef.current = fn;
 
-  const memoizedCallback = useCallback(() => fnRef.current(), []);
+  const memoizedCallback = useCallback((...args: Parameters<T>) => fnRef.current(...args), []);
 
   // 항상 같은 참조를 반환하되, 내부에서 최신 fn을 호출
   return memoizedCallback as T;

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,7 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import type { DependencyList } from "react";
+import { useMemo } from "./useMemo";
 
-export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
-  // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+export function useCallback<T extends Function>(factory: T, _deps: DependencyList): T {
+  // useMemo를 사용하여 함수를 메모이제이션
+  return useMemo(() => factory, _deps);
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -1,8 +1,19 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import type { DependencyList } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "./useRef";
 
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+  const valueRef = useRef<T | null>(null);
+  const depsRef = useRef<DependencyList>([]);
+  const isFirstRenderRef = useRef(true);
+
+  // 첫 번째 렌더링이거나 의존성이 변경되었는지 확인
+  if (isFirstRenderRef.current || !_equals(depsRef.current, _deps)) {
+    // 변경되었다면 factory 실행하고 결과 저장
+    valueRef.current = factory();
+    depsRef.current = _deps;
+    isFirstRenderRef.current = false;
+  }
+
+  return valueRef.current as T;
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -5,15 +5,12 @@ import { useRef } from "./useRef";
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
   const valueRef = useRef<T | null>(null);
   const depsRef = useRef<DependencyList>([]);
-  const isFirstRenderRef = useRef(true);
 
-  // 첫 번째 렌더링이거나 의존성이 변경되었는지 확인
-  if (isFirstRenderRef.current || !_equals(depsRef.current, _deps)) {
-    // 변경되었다면 factory 실행하고 결과 저장
+  if (valueRef.current === null || !_equals(depsRef.current, _deps)) {
+    // 변경되었거나 첫 렌더링인 경우 factory 실행하고 결과 저장
     valueRef.current = factory();
     depsRef.current = _deps;
-    isFirstRenderRef.current = false;
   }
 
-  return valueRef.current as T;
+  return valueRef.current;
 }

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,4 +1,8 @@
+import { useState } from "react";
+
 export function useRef<T>(initialValue: T): { current: T } {
-  // useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  // useState의 lazy initialization을 이용
+  const [ref] = useState(() => ({ current: initialValue }));
+
+  return ref;
 }

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -1,6 +1,6 @@
 import type { RouterInstance } from "../Router";
 import type { AnyFunction } from "../types";
-import { useSyncExternalStore } from "react";
+// import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
 
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -1,6 +1,6 @@
 import type { RouterInstance } from "../Router";
 import type { AnyFunction } from "../types";
-// import { useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
 
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
@@ -8,5 +8,9 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 export const useRouter = <T extends RouterInstance<AnyFunction>, S>(router: T, selector = defaultSelector<T, S>) => {
   // useSyncExternalStore를 사용하여 router의 상태를 구독하고 가져오는 훅을 구현합니다.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(router);
+
+  return useSyncExternalStore(
+    (onStoreChange) => router.subscribe(onStoreChange),
+    () => shallowSelector(router),
+  );
 };

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -1,5 +1,5 @@
-import { useRef } from "react";
-import { shallowEquals } from "../equals";
+// import { useRef } from "react";
+// import { shallowEquals } from "../equals";
 
 type Selector<T, S = T> = (state: T) => S;
 

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -1,9 +1,20 @@
-// import { useRef } from "react";
-// import { shallowEquals } from "../equals";
+import { useRef } from "react";
+import { shallowEquals } from "../equals";
 
 type Selector<T, S = T> = (state: T) => S;
 
 export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
-  // 이전 상태를 저장하고, shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
-  return (state: T): S => selector(state);
+  const prevResultRef = useRef<S | null>(null);
+
+  return (state: T): S => {
+    const result = selector(state);
+
+    if (prevResultRef.current && shallowEquals(prevResultRef.current, result)) {
+      return prevResultRef.current;
+    }
+
+    prevResultRef.current = result;
+
+    return result;
+  };
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { shallowEquals } from "../equals";
+// import { shallowEquals } from "../equals";
 
 export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
   // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,7 +1,17 @@
 import { useState } from "react";
-// import { shallowEquals } from "../equals";
+import { shallowEquals } from "../equals";
+import { useCallback } from "./useCallback";
 
-export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
-  // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
-  return useState(initialValue);
+export const useShallowState = <T>(initialValue: T) => {
+  const [value, setValue] = useState(initialValue);
+
+  const setValueWithShallowEquals = useCallback((newValue: T) => {
+    if (shallowEquals(value, newValue)) {
+      return;
+    }
+
+    setValue(newValue);
+  }, []);
+
+  return [value, setValueWithShallowEquals] as const;
 };

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+// import { useSyncExternalStore } from "react";
 import type { createStorage } from "../createStorage";
 
 type Storage<T> = ReturnType<typeof createStorage<T>>;

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -10,6 +10,5 @@ export const useStorage = <T>(storage: Storage<T>) => {
   return useSyncExternalStore(
     (onStoreChange) => storage.subscribe(onStoreChange),
     () => storage.get(),
-    () => storage.get(),
   );
 };

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -1,9 +1,15 @@
 // import { useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import type { createStorage } from "../createStorage";
 
 type Storage<T> = ReturnType<typeof createStorage<T>>;
 
 export const useStorage = <T>(storage: Storage<T>) => {
   // useSyncExternalStore를 사용해서 storage의 상태를 구독하고 가져오는 훅을 구현해보세요.
-  return storage.get();
+
+  return useSyncExternalStore(
+    (onStoreChange) => storage.subscribe(onStoreChange),
+    () => storage.get(),
+    () => storage.get(),
+  );
 };

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -1,5 +1,5 @@
 import type { createStore } from "../createStore";
-import { useSyncExternalStore } from "react";
+// import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
 
 type Store<T> = ReturnType<typeof createStore<T>>;

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -1,3 +1,4 @@
+import { useSyncExternalStore } from "react";
 import type { createStore } from "../createStore";
 // import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
@@ -9,5 +10,9 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 export const useStore = <T, S = T>(store: Store<T>, selector: (state: T) => S = defaultSelector<T, S>) => {
   // useSyncExternalStore와 useShallowSelector를 사용해서 store의 상태를 구독하고 가져오는 훅을 구현해보세요.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(store.getState());
+
+  return useSyncExternalStore(
+    (onStoreChange) => store.subscribe(onStoreChange),
+    () => shallowSelector(store.getState()),
+  );
 };


### PR DESCRIPTION
## 과제 체크포인트

### 배포 링크

https://hanghae-plus.github.io/front_6th_chapter1-3/

### 기본과제

#### equalities

- [x] shallowEquals 구현 완료
- [x] deepEquals 구현 완료

#### hooks

- [x] useRef 구현 완료
- [x] useMemo 구현 완료
- [x] useCallback 구현 완료
- [x] useDeepMemo 구현 완료
- [x] useShallowState 구현 완료
- [x] useAutoCallback 구현 완료

#### High Order Components

- [x] memo 구현 완료
- [x] deepMemo 구현 완료

### 심화 과제

#### hooks

- [x] createObserver를 useSyncExternalStore에 사용하기 적합한 코드로 개선
- [x] useShallowSelector 구현
- [x] useStore 구현
- [x] useRouter 구현
- [x] useStorage 구현

### context

- [x] ToastContext, ModalContext 개선

## 과제 셀프회고

과제를 진행하며 기존에 알고있던 지식도 한번 더 다지고 새로 알게 된 메서드와 해당 훅을 제공하는 라이브러리에서는 어떻게, 왜 이렇게 구현했는지 한번 비교해보고 학습했습니다. 과제테스트를 통과한 후 다른 분들에게 도움을 드렸던 문제들을 정리해봤습니다. 예전에 눈으로만 보며 넘어가서 어렴풋이만 알고있던 지식들을 기록해보며 머릿속에 넣어보려 노력했습니다!

### 기술적 성장

<details>
<summary>자바스크립트의 원시&참조 타입</summary>

<br />
JavaScript의 원시타입과 참조타입을 다룹니다. 타입을 정확히 이해하면 변수 할당, 함수 파라미터 전달, 상태 관리에서 예상치 못한 버그를 방지할 수 있습니다. 특히 React나 상태 관리 라이브러리를 사용할 때 얕은 비교 동작을 이해하는 데 핵심적인 지식이 됩니다.

### 원시타입

원시타입은 JavaScript에서 값 자체가 변수에 직접 저장되는 가장 기본적인 데이터 타입입니다. 객체나 배열과 달리 메모리 주소가 아닌 실제 값이 저장되어, 변수 간 할당 시 값이 복사됩니다.

**7가지 원시타입**

JavaScript는 다음 7가지 원시타입을 제공합니다:

- number: 정수와 실수 (42, 3.14, Infinity)
- string: 문자열 ("hello", 'world', `template`)
- boolean: 논리값 (true, false)
- null: 의도적인 빈 값
- undefined: 값이 할당되지 않은 상태

**특수 원시타입**

- symbol: 유일한 식별자 생성 (ES6+)
- bigint: 큰 정수 처리 (ES2020+)

### Symbol 타입 이해하기

Symbol은 **변경 불가능(immutable)하고 유일함을 보장**하는 원시타입입니다. 주로 객체 프로퍼티의 충돌 없는 키를 만들 때 사용합니다.

```js
const user = {};
const id1 = Symbol('id'); // 인자의 문자열은 단지 description의 역할밖에 하지 않는다.
const id2 = Symbol('id');

user[id1] = 'user1';
user[id2] = 'user2';

console.log(user[id1]); // 'user1'
console.log(user[id2]); // 'user2'
console.log(id1 === id2); // false (같은 설명이어도 다른 값)
```
- 같은 문자열로 생성해도 항상 다른 값
- 열거되지 않는다.
- 문자열 인자는 디버깅 용도일 뿐, 값에 영향이 없다.

Symbol 함수의 정적 프로퍼티 중 **Well-Known Symbol**이라 불리는 특별한 심볼들이 있습니다. 이 Well-Known Symbol은 자바스크립트 엔진에 상수로 존재해 이 값을 참조해 일정한 처리를 진행합니다.

일정한 처리라 함은 어떠한 객체가 Symbol.iterator를 프로퍼티 key로 하는 메소드를 가지고 있다면 자바스크립트 엔진은 이 객체가 **이터레이션 프로토콜**을 따른다고 생각하고 이터레이터하게 동작하게 합니다.

저희가 사용하는 빌트인 객체 Array, String 등 순회 가능한 객체는 모두 내부에 Symbol.iterator를 가지고 있기에 이터레이션 프로토콜을 따라 반복문, 스프레드 연산자의 사용이 가능합니다.

```js
// Symbol.iterator를 키로 사용한 메소드
const iterableObj = {
  data: [1, 2, 3],
  [Symbol.iterator]() {
    let index = 0;
    const data = this.data;
    return {
      next() { // 일반 함수 사용
        if (index < data.length) {
          return { value: data[index++], done: false };
        }
        return { done: true };
      }
    };
  }
};

for (const value of iterableObj) {
  console.log(value); // 1, 2, 3
}
```

<img width="600" height="514" alt="image" src="https://github.com/user-attachments/assets/68cab67b-c169-4649-81d1-65bd3f310786" />

### bigint

bigint는 **임의의 정밀도로 정수를 나타낼 수 있는** 원시 타입입니다. Number 타입의 안전한 정수 범위(2^53 - 1)를 넘어서는 큰 정수를 다룰 때 사용됩니다.

```js
// Number의 한계
console.log(Number.MAX_SAFE_INTEGER); // 9007199254740991
console.log(Number.MAX_SAFE_INTEGER + 1 === Number.MAX_SAFE_INTEGER + 2); // true (정밀도 손실)

// BigInt 사용
const bigNum1 = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
const bigNum2 = BigInt(Number.MAX_SAFE_INTEGER) + 2n;

console.log(bigNum1 === bigNum2); // false (정확한 계산)
console.log(typeof bigNum1); // "bigint"
```

### 원시타입과 참조타입의 차이

참조 타입은 위에서 설명한 타입 외에 모든 객체, 배열 등이 참조 타입으로 분류됩니다. JavaScript의 데이터 타입을 이해하려면 원시타입과 참조타입의 근본적인 차이를 알아야 합니다. 이 차이는 변수 할당, 함수 인자 전달, 비교 연산에서 완전히 다른 동작을 보입니다.

**값 저장 방식의 차이**

원시타입: 변수에 실제 값이 직접 저장됩니다.

```js
let a = 10;
let b = a;    // 값 10이 복사되어 저장
a = 20;       // a만 변경됨
console.log(a); // 20
console.log(b); // 10 (영향받지 않음)
```

참조타입: 변수에 **메모리 주소(참조)**가 저장됩니다.

```js
let obj1 = { value: 10 };
let obj2 = obj1;  // 메모리 주소가 복사되어 같은 객체를 참조
obj1.value = 20;  // 같은 객체를 수정
console.log(obj1.value); // 20
console.log(obj2.value); // 20 (같은 객체이므로 함께 변경)
```

**비교 연산의 차이**

원시타입: 값 자체를 비교합니다.

```js
let a = 5;
let b = 5;
console.log(a === b); // true (같은 값)

let str1 = "hello";
let str2 = "hello";
console.log(str1 === str2); // true (같은 값)
```

참조타입: 메모리 주소를 비교합니다.

```js
let obj1 = { value: 5 };
let obj2 = { value: 5 };
console.log(obj1 === obj2); // false (다른 메모리 주소)

let obj3 = obj1;
console.log(obj1 === obj3); // true (같은 메모리 주소)
```

**함수 인자 전달의 차이**

원시타입: Call by Value (값에 의한 전달)

```js
function changeValue(x) {
  x = 100;  // 복사된 값만 변경
}

let num = 50;
changeValue(num);
console.log(num); // 50 (원본 변수는 변경되지 않음)
```

참조타입: Call by Reference (참조에 의한 전달)

```js
function changeObject(obj) {
  obj.value = 100;  // 같은 객체를 수정
}

let myObj = { value: 50 };
changeObject(myObj);
console.log(myObj.value); // 100 (원본 객체가 변경됨)
```

💡 이러한 차이점은 React 사용 시 알아야 하는 불변성 개념과 직결됩니다. 특히 참조타입을 다룰 때 의도치 않게 원본 객체나 배열을 변경하여 예상과 다른 동작을 일으킬 수 있으므로, 두 타입의 차이점을 명확히 이해하고 코드를 작성하는 것이 중요합니다.

</details>

<details>
<summary>얕은 비교, 깊은 비교</summary>

### 자바스크립트에서의 비교

자바스크립트에서 값을 비교하는 연산자는 두 가지입니다.

- 동등연산자(==): 값만 비교하고 타입은 무시합니다.
- 일치연산자(===): 값과 타입을 모두 비교합니다.

대부분의 경우 일치연산자로 충분하지만, 다음과 같은 특수한 경우에는 예상과 다른 결과가 나올 수 있습니다.

```js
// 일치 연산자의 경우
NaN === NaN  // false
+0 === -0    // true
```

정확한 비교가 필요하다면 Object.is() 메서드를 사용 해야합니다.

```js
Object.is(NaN, NaN)  // true
Object.is(+0, -0)    // false
```

Object.is()는 일치연산자와 거의 동일하지만, NaN과 ±0을 올바르게 구분합니다.

### 얕은 비교 (shallowEqual)

**얕은 비교(Shallow Comparison)** 는 다음과 같이 동작한다고 알려져 있습니다.
> 원시 타입: 값 자체를 비교
> 참조 타입: 참조(메모리 주소)만 비교

하지만 React와 Zustand에서의 얕은 비교는 다르게 동작합니다.

Zustand의 얕은 비교 코드:

```ts
// src/react/shallow.ts
export function shallow<T>(valueA: T, valueB: T): boolean {

  if (Object.is(valueA, valueB)) { // 값을 비교
    return true
  }
  if (
    typeof valueA !== 'object' ||
    valueA === null ||
    typeof valueB !== 'object' ||
    valueB === null // null 체크 및 타입 검사
  ) {
    return false
  }
  if (Object.getPrototypeOf(valueA) !== Object.getPrototypeOf(valueB)) { // prototype을 검사 Array.prototype, Object.prototype ....etc
    return false
  }
  if (isIterable(valueA) && isIterable(valueB)) { // isIterable은 해당 value에 Symbol.iterator 가 존재하는지 확인한다.
    if (hasIterableEntries(valueA) && hasIterableEntries(valueB)) { // hasIterableEntries은 entries 메서드가 존재하는지 확인한다. Map, Set의 경우
      return compareEntries(valueA, valueB) // 이미 entries 메서드가 존재하면 실행
    }
    return compareIterables(valueA, valueB) // entries가 존재하지 않으면 실행
  }
  // assume plain objects 일반 객체 처리
  return compareEntries(
    { entries: () => Object.entries(valueA) },
    { entries: () => Object.entries(valueB) },
  )
}
```
 
Zustand의 얕은 비교는 객체와 배열의 최상위 레벨 값까지 비교합니다. compareEntries와 compareIterables 함수가 객체를 순회하며 값을 비교합니다.

```ts
// src/react/shallow.ts
const compareEntries = (
  valueA: { entries(): Iterable<[unknown, unknown]> },
  valueB: { entries(): Iterable<[unknown, unknown]> },
) => {
  const mapA = valueA instanceof Map ? valueA : new Map(valueA.entries())
  const mapB = valueB instanceof Map ? valueB : new Map(valueB.entries())
  if (mapA.size !== mapB.size) {
    return false
  }
  for (const [key, value] of mapA) {
    if (!Object.is(value, mapB.get(key))) {
      return false
    }
  }
  return true
}

const compareIterables = (
  valueA: Iterable<unknown>,
  valueB: Iterable<unknown>,
) => {
  const iteratorA = valueA[Symbol.iterator]()
  const iteratorB = valueB[Symbol.iterator]()
  let nextA = iteratorA.next()
  let nextB = iteratorB.next()
  while (!nextA.done && !nextB.done) {
    if (!Object.is(nextA.value, nextB.value)) {
      return false
    }
    nextA = iteratorA.next()
    nextB = iteratorB.next()
  }
  return !!nextA.done && !!nextB.done
}
```

compareEntries 함수는 어댑터 패턴을 통해 Map, Set, 일반객체를 순회하며 값을 비교합니다. compareIterables 함수는 entries 메서드가 없는 Array, String 등의 데이터를 순회하며 비교합니다.

React의 shallowEqual도 유사한 방식으로 동작합니다:

```js
// react/packages/shared/shallowEqual.js

function shallowEqual(objA: mixed, objB: mixed): boolean {
  if (is(objA, objB)) { // is 함수는 단지 Object.is() 함수를 분리해놓은 함수입니다.
    return true;
  }

  if (
    typeof objA !== 'object' ||
    objA === null ||
    typeof objB !== 'object' ||
    objB === null
  ) {
    return false;
  }

  const keysA = Object.keys(objA);
  const keysB = Object.keys(objB);

  if (keysA.length !== keysB.length) {
    return false;
  }

  // Test for A's keys different from B.
  for (let i = 0; i < keysA.length; i++) {
    const currentKey = keysA[i];
    if (
      !hasOwnProperty.call(objB, currentKey) ||
      // $FlowFixMe[incompatible-use] lost refinement of `objB`
      !is(objA[currentKey], objB[currentKey])
    ) {
      return false;
    }
  }

  return true;
}
```

실제로 얕은 비교 코드를 구현할 때는 일반적으로 알려진 얕은 비교(메모리 주소만 참조)와 달리, 객체의 최상위 레벨 속성까지 비교하는 방식을 사용해야 합니다.

### 깊은 비교

깊은 비교는 객체나 배열의 중첩된 모든 속성을 재귀적으로 비교하는 방식입니다. React나 Zustand 같은 라이브러리에서는 성능상의 이유로 일반적으로 사용하지 않으며, 객체 크기에 따라 비용이 기하급수적으로 증가합니다.

```ts
export const deepEquals = (a: unknown, b: unknown) => {
  // 1. 값이 같으면 바로 true 반환 참조 타입의 경우 주소 비교
  if (Object.is(a, b)) {
    return true;
  }

  // 2. 원시 값 처리
  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) {
    return Object.is(a, b);
  }

  // 3. 배열 깊은비교 재귀
  if (Array.isArray(a) && Array.isArray(b)) {
    if (a.length !== b.length) {
      return false;
    }

    for (let i = 0; i < a.length; i++) {
      if (!deepEquals(a[i], b[i])) return false;
    }

    return true;
  }

  // 4. 객체 깊은비교 재귀
  const keysA = Object.keys(a);
  const keysB = Object.keys(b);

  if (keysA.length !== keysB.length) {
    return false;
  }

  for (const key of keysA) {
    if (!deepEquals(a[key as keyof typeof a], b[key as keyof typeof b])) return false;
  }

  return true;
};
```

얕은 비교와 달리 배열이나 객체의 중첩된 구조를 만날 때마다 즉시 재귀 호출을 통해 더 깊은 레벨(DFS)로 들어가 끝까지 파고들어 비교를 완료합니다.

**JSON.stringify() 방식**

간혹 JSON.stringify()를 통한 비교를 사용하는 경우가 있지만, 여러 문제점이 존재합니다:

1. 속성 순서 의존성
```js
const obj1 = { a: 1, b: 2 };
const obj2 = { b: 2, a: 1 };

JSON.stringify(obj1); // '{"a":1,"b":2}'
JSON.stringify(obj2); // '{"b":2,"a":1}'

// 같은 내용이지만 false!
deepEqualsJSON(obj1, obj2); // false
```

2. 성능 문제
```js
const largeObj = { /* 매우 큰 객체 */ };

// JSON.stringify는 전체 객체를 문자열로 변환
// 메모리 사용량이 2배가 됨 (원본 + 문자열)
// 불필요한 문자열 생성 비용 및 문자열 비교의 비용은 작지 않다.
```

이외에도 NaN, Infinity 같은 특수 값 처리 불가, 데이터 손실 가능성, 함수나 undefined 값 무시 같은 문제가 있습니다. 다음과 같은 제한적인 상황에서는 고려해볼 수 있습니다:

```js
// 1. 간단한 plain object만 비교
const config1 = { timeout: 5000, retries: 3 };
const config2 = { timeout: 5000, retries: 3 };

// 2. 속성 순서가 보장되는 경우 (같은 소스에서 생성)
const response1 = JSON.parse(apiResponse);
const response2 = JSON.parse(apiResponse);

// 3. 프로토타이핑이나 간단한 테스트
```

### React에서의 실용적 활용

React와 연계해서 사용하기에는 memo의 두 번째 인자에 직접 비교 함수를 제공하는 방식이 더 적합합니다:

```js
const MemoizedComponent = memo(SomeComponent, arePropsEqual);
// arePropsEqual은 콜백 함수로 prevProps와 currentProps를 받습니다
```

**추가 팁**

💡 React의 불변성을 지키기 위해 깊은 복사가 필요하다면 [lodash-es](https://github.com/lodash/lodash)의 cloneDeep 함수를 이용하면 간편하게 깊은 복사를 통해 새로운 객체를 얻을 수 있습니다.

</details>

<details>
<summary>트러블슈팅 지원 사례</summary>

### Q1. useRef에 왜 함수를 넣어줘야 하나요?

이 useRef 구현에서 useState에 함수를 전달하는 이유는 **불필요한 객체 생성을 방지**하기 위해서입니다.

```jsx
const [ref] = useState({ current: initialValue }); // 매번 새 객체 생성
```

위처럼 작성하면 컴포넌트가 리렌더링될 때마다 { current: initialValue } 객체가 새로 생성됩니다. useState는 초기값을 한 번만 사용하지만, 객체 생성 자체는 매번 발생합니다.

이를 해결하는 방법이 지연 초기화(lazy initialization)입니다.
```jsx
const [ref] = useState(() => ({ current: initialValue })); // 최초 한 번만 실행
```
함수를 전달하면 useState가 최초 렌더링 시에만 함수를 실행하여 객체를 생성합니다. 이후 리렌더링에서는 함수가 실행되지 않아 불필요한 객체 생성을 방지합니다.

React의 실제 구현에서 이를 확인할 수 있습니다:

```jsx
// react/packages/react-reconciler/src/ReactFiberHooks.js

// 최초 렌더링 시 실행
function mountStateImpl<S>(initialState: (() => S) | S): Hook {
  const hook = mountWorkInProgressHook();
  
  if (typeof initialState === 'function') {
    const initialStateInitializer = initialState;
    initialState = initialStateInitializer(); // 함수 실행
  }
  // ... 생략
}

// 업데이트 시 실행
function updateReducerImpl<S, A>(
  hook: Hook,
  current: Hook,
  reducer: (S, A) => S,
): [S, Dispatch<A>] {
  const queue = hook.queue;
  // 초기값 재실행 없이 큐에서 상태 처리
  queue.lastRenderedReducer = reducer;
}

// mountWorkInProgressHook, updateWorkInProgressHook부터 살펴봐야 하지만 너무 길어져 넘기겠습니다.😅
```

- 마운트 시: mountStateImpl에서 typeof initialState === 'function' 검사 후 함수 실행
- 업데이트 시: updateReducerImpl에서 배치 업데이트를 위해 fiber의 큐에 변경사항만 저장, 초기값 함수는 재실행하지 않음

이는 React에서 인라인 스타일을 권장하지 않는 이유와 동일합니다. 렌더링 과정에서 객체 리터럴은 항상 새로운 참조를 생성하기 때문입니다.
이번과제 ToastContext 구축 시 value 부분에도 적용되는 개념입니다.👀

참고문서
- [React Github Code](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberHooks.js#L1891-L1917)

### Q2. useMemo에 return에 왜 에러가 뜨는지 모르겠어요

문제 코드
```tsx
export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
  const valueRef = useRef<T | undefined>(undefined);
  const depsRef = useRef<DependencyList>([]);

  if (!_equals(depsRef.current, _deps)) {
    valueRef.current = factory();
    depsRef.current = _deps;
  }

  return valueRef.current; // error : 'T | undefined' 형식은 'T' 형식에 할당할 수 없습니다.
```

TypeScript 에러입니다. useMemo 훅의 반환 타입은 T로 정의했지만, valueRef.current는 undefined일 가능성이 있어 타입 불일치가 발생합니다.

해결 방법: 초기 상태 처리 추가
```tsx
export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
  const valueRef = useRef<T | undefined>(undefined);
  const depsRef = useRef<DependencyList>([]);

 // 초기 렌더링이거나 의존성이 변경된 경우
  if (valueRef.current === undefined || !_equals(depsRef.current, _deps)) {
    valueRef.current = factory();
    depsRef.current = _deps;
  }

  return valueRef.current; // 이제 T 타입으로 추론됨
```

valueRef.current === undefined 조건을 추가하여 초기 렌더링 시 undefined 상태를 처리합니다. 이제 반환 시점에는 항상 T 타입이 보장됩니다.

</details>

### 학습 효과 분석

이번 과제를 통해 일반적인 얕은 비교와 React의 얕은 비교 방식이 다르다는 점을 파악했습니다. 
기초적인 타입별 특징과 메모리 할당 방식을 다시 학습했고, 참조 타입 사용 시 React의 불변성 원칙을 지키는 방법을 정리했습니다.

Zustand와 React의 얕은 비교 구현 코드를 분석한 결과, Zustand는 Symbol.iterator 활용, Map과 Set 객체 처리, Object.is 메서드 사용 등 더 정교한 비교 로직을 구현하고 있음을 확인했습니다.

과제를 빠르게 진행하여 다른분들의 문제를 파악해보며 설명하는 과정에서 왜? 를 납득시키기 위한 좀 더 논리적인 원리를 파고드는 경험도 했습니다.

현재 과제는 Preact의 방식과 유사한 패턴이지만 좀 더 대규모 환경인 React의 코드를 헤집어보며 hook 실행 시점과 지연초기화가 어떻게 가능한지 학습했습니다. (몇천줄 속에서 코드 찾는 요령이 늘은 것 같아요 👍)

### 과제 피드백

useAutoCallback 구현 시 인자를 전달하지 않아도 테스트가 통과하는 부분이 있었습니다. (E2E 제외)
UnitTest가 추가되어도 괜찮겠다! 생각이 들었습니다.

현 React의 구조는 너무 복잡한데 Preact로 접근해서 풀어보는 방식이 새롭고 좋았습니다!! 쉽게 배우고 -> 깊게 들어가는 느낌

## 학습 갈무리

### 리액트의 렌더링이 어떻게 이루어지는지 정리해주세요.

저는 React 내부적으로 렌더링이 일어나는 순서에 대해 딥다이브하며 한번 작성해봤습니다.

**Fiber 아키텍처**

Fiber는 React 16부터 도입된 **재조정(Reconciliation) 엔진**입니다. 각 컴포넌트나 요소를 객체로 표현합니다. 이하 설명은 Fiber 아키텍처의 렌더링 과정입니다.

Fiber 노드의 구조:
```ts
// Fiber 노드
{
  type: 'div' | Component,
  props: {...},
  child: null,
  sibling: null,
  return: null,
  alternate: null,
  effectTag: NoEffect,
  stateNode: DOMElement 
  // ... 생략
}
```

**두 단계의 렌더링 과정**

React의 렌더링은 두 단계로 나누어 집니다.

<img width="1116" height="659" alt="image" src="https://github.com/user-attachments/assets/e10592cb-be53-4125-9694-f3af3f391eb1" />

Render Phase (렌더 단계)

- Virtual DOM을 조작하여 변경점을 계산하는 단계입니다
- Fiber 아키텍처를 통해 작업을 중단, 재시작할 수 있습니다
- 동시성 모드에서 비동기적으로 실행됩니다
- 컴포넌트 함수를 호출하고 Virtual DOM에만 반영하며, 실제 DOM은 변경하지 않습니다

Commit Phase (커밋 단계)

- Render Phase에서 계산된 변경사항을 실제 DOM에 적용합니다
- 라이프사이클 메서드와 훅을 실행합니다
- 일관된 화면 업데이트를 위해 동기적으로 실행됩니다
- **모든 작업 완료 후** 브라우저가 화면을 다시 그립니다 (Paint)

**이중 트리 구조**

React는 두 개의 트리를 동시에 관리합니다.
- Current Tree: 현재 화면에 표시된 상태 트리
- Work-in-Progress Tree: 업데이트가 적용되는 새로운 상태 트리

이 구조는 더블 버퍼링 방식으로 작동합니다. 백그라운드에서 새로운 트리를 구성하고, 완료되면 포인터를 교체하여 새 트리를 활성화합니다. 이를 통해 작업 중단과 재시작, 우선순위 기반 업데이트가 가능합니다.

> 한줄로 표현해보자면 React의 렌더링은 **Render Phase(Virtual DOM 조작 및 비교) → Commit Phase(실제 DOM 반영)**의 두 단계를 반복하며(loop) Fiber 아키텍처기반으로 현재 보여지는 currentTree, 변경사항에 대한 업데이트를 진행중인 Work-in-Progress Tree 통해 효율적이게 렌더링을 진행합니다.

현재의 동작이 마운트냐, 업데이트냐에 따라 달라지는 WorkLoop 부분도 확인했지만 스케쥴러부터 관련 함수들까지의 양이 너무 방대해 아직 완벽하게 흐름을 이해하지 못했습니다.😅

관련 아티클
[React 톺아보기 -2](https://goidle.github.io/react/in-depth-react-intro)

### 메모이제이션에 대한 나의 생각을 적어주세요.

개인적인 생각으로는 메모이제이션 훅은 예기치 못한 동작들을 원하는 방향으로 돌아갈 수 있게 도와주는 훅에 더 가깝다고 느꼈습니다.

물론 대규모 프로젝트나 빅 데이터를 다루지 못했기에 이런 결론에 도달했을 수 있지만, 조금 더 근본적인 생각으로 돌아가보자면 이 메모이제이션 훅들은 렌더링을 개선해주고 큰 계산의 결과값을 캐싱하는 용도로 나온 훅으로 알고있습니다.

그런데 이 훅들을 사용하지 않았을 때 버벅임이나 성능적인 문제가 아니라 기술적인 오류가 발생한다면 가장 먼저 **내가 컴포넌트의 구조를 잘못 잡았나?** 부터 생각해보고 이 훅들을 사용하지 않아도 "정상적"으로 돌아가는 방향으로 개선하는걸 우선해볼 것 같습니다.

분명 이 메모이제이션 훅들은 필요한 훅이지만 비용이 적지 않은 만큼 내가 설계한 방향이 맞았나? 더 나은 방법은 없을까? 라고 리팩토링의 고민을 하게 해줄 수 있는 훅이라고 생각해봤습니다 🙇‍♂️

### 컨텍스트와 상태관리에 대한 나의 생각을 적어주세요.

**왜 컨텍스트와 상태관리가 필요한가?**

Props Drilling의 한계

컴포넌트 트리가 깊어질수록 props 전달 체인이 길어집니다. 특히 중간 컴포넌트들이 자신은 사용하지 않는 데이터를 단순히 하위 컴포넌트로 전달하기 위해서만 존재하게 되는 상황이 발생합니다. 이는 변경점 발생 시 모든 중간 단계 컴포넌트를 수정해야 하는 문제로 이어집니다.

형제 컴포넌트 간 데이터 공유의 복잡성

React의 단방향 데이터 흐름에서 형제 컴포넌트끼리 직접 소통할 방법이 없습니다. 데이터를 공유하려면 가장 가까운 공통 부모 컴포넌트까지 상태를 끌어올려야 하는데, 이는 상위 컴포넌트의 책임을 무겁게 만들고 컴포넌트 간 결합도를 높입니다.

전역 상태 관리의 필요성

애플리케이션 전반에서 사용되는 데이터(인증 상태, 설정 값 등)는 컴포넌트 계층과 상관없이 접근할 수 있어야 합니다. props로 이런 데이터를 전달하면 모든 컴포넌트가 이 데이터에 의존하게 되어 결합도가 높아집니다.
결국 컨텍스트와 상태관리는 **"데이터가 필요한 곳에서 바로 접근할 수 있게 해주는 도구"** 라는 생각이 들었습니다.

**컨텍스트와 상태관리를 사용하지 않으면 어떤 문제가 발생할까?**

인터페이스 변경 시 수정 범위 확산

props로 전달되는 데이터의 타입이나 구조가 변경되면, 해당 데이터를 전달하는 모든 중간 컴포넌트의 props 인터페이스를 수정해야 합니다. 이는 변경의 영향 범위를 예측하기 어렵게 만들고, 실수로 누락되는 부분이 생길 가능성을 높입니다.

컴포넌트의 독립성 저하

특정 props에 의존하는 컴포넌트는 해당 props를 제공하는 상위 컴포넌트 없이는 동작할 수 없습니다. 이는 컴포넌트의 재사용성을 제한합니다.

상태 일관성 관리의 어려움

동일한 데이터를 여러 컴포넌트에서 각각 관리하면 데이터 동기화 문제가 발생합니다. 한 곳에서 데이터가 업데이트되어도 다른 곳의 데이터는 이전 상태를 유지하는 불일치가 생길 수 있습니다.

중복 연산과 메모리 비효율성

같은 데이터 가공 로직이 여러 컴포넌트에 분산되어 있으면 동일한 계산이 중복으로 수행됩니다. 또한 비슷한 상태를 여러 곳에서 관리하면 메모리 사용량이 불필요하게 증가할 수 있습니다.

**컨텍스트의 다양한 활용법**

컴파운드 컴포넌트 패턴으로 제한된 범위의 Context 활용

전역 Context의 리렌더링 문제를 피하면서도 관련 컴포넌트들끼리는 상태를 공유할 수 있는 절충안입니다. 특정 기능 단위로 Context 범위를 제한하여 해당 영역 내에서만 상태를 공유합니다.
이 패턴은 Modal, Accordion, Tab 등 UI 컴포넌트에서 내부 상태를 공유해야 할 때 특히 유용합니다. 컴포넌트의 내부 구현은 Context를 사용하지만 외부에서는 일반적인 props 인터페이스로 사용할 수 있어 캡슐화가 잘 됩니다.

Custom Hooks를 통한 상태 로직 재사용

상태 관리 로직을 훅으로 분리하면 여러 컴포넌트에서 동일한 상태 패턴을 재사용할 수 있습니다. 전역 상태 없이도 비슷한 상태 로직이 필요한 컴포넌트들에서 일관된 동작을 구현할 수 있습니다.
localStorage나 sessionStorage와의 동기화, API 호출 상태 관리, 폼 validation 등의 로직을 훅으로 만들어 재사용하는 방식입니다.

서버 상태 관리 라이브러리 활용

React Query, SWR 같은 라이브러리를 사용하면 서버에서 가져오는 데이터는 별도로 관리할 수 있습니다. 캐싱, 동기화, 백그라운드 업데이트를 자동으로 처리해주므로 클라이언트 상태와 서버 상태를 분리하여 복잡성을 줄일 수 있습니다.

## 리뷰 받고 싶은 내용

**ToastProvider**

- hideAfter에 useMemo를 사용하지 않을 방법은 없었을까요? useAutoCallback을 사용하면 내부 디바운싱에서 타이머가 초기화되지 않는 문제가 있었습니다. 함수를 메모이제이션 하는거니까 useCallback쪽이 더 어울린다고 생각이 들어서요!
```tsx
const hideAfter = useAutoCallback(debounce(hide, DEFAULT_DELAY));

// ⚠️타이머가 비정상으로 동작해서 Toast가 꺼지지않음
export const debounce = <T extends AnyFunction>(callback: T, delay: number) => {
  let timeoutId: ReturnType<typeof window.setTimeout> | null = null;

  return (...args: Parameters<T>) => {
    if (timeoutId) {
      clearTimeout(timeoutId);
    }
    timeoutId = setTimeout(() => {
      callback(...args);
      timeoutId = null;
    }, delay);
  };
};
```

- 이런 Provider 구현 시 useReducer가 더 좋을까요? 저는 useState로 상태값을 두고 handle함수를 Provider 내부에 둔 상태가 한눈에 보여 파악하기 쉽다고 생각했습니다! 코치님은 useReducer를 선호하시나요?? 이유도 궁금합니다!
```tsx
/* eslint-disable react-refresh/only-export-components */
import { useAutoCallback } from "@hanghae-plus/lib";
import { createContext, memo, type PropsWithChildren, useContext, useMemo, useReducer } from "react";
import { createPortal } from "react-dom";
import { debounce } from "../../utils";
import { Toast } from "./Toast";
import { createActions, initialState, toastReducer, type ToastType } from "./toastReducer";

type ShowToast = (message: string, type: ToastType) => void;
type Hide = () => void;

const ToastContext = createContext<{
  message: string;
  type: ToastType;
}>({
  ...initialState,
});

const ToastCommandContext = createContext<{
  show: ShowToast;
  hide: Hide;
}>({
  show: () => null,
  hide: () => null,
});

const DEFAULT_DELAY = 3000;

const useToastContext = () => useContext(ToastContext);
const useToastCommandContext = () => useContext(ToastCommandContext);

export const useToastCommand = () => {
  const { show, hide } = useToastCommandContext();
  return { show, hide };
};
export const useToastState = () => {
  const { message, type } = useToastContext();
  return { message, type };
};

export const ToastProvider = memo(({ children }: PropsWithChildren) => {
  const [state, dispatch] = useReducer(toastReducer, initialState);
  const { show, hide } = useMemo(() => createActions(dispatch), [dispatch]); // ⚠️ 어떻게 동작하는지 확인하려면 별도 파일 확인이 필요함
  const visible = state.message !== "";

  const hideAfter = useAutoCallback(debounce(hide, DEFAULT_DELAY));

  const showWithHide: ShowToast = useAutoCallback((...args) => {
    show(...args);
    hideAfter();
  });

  const command = useMemo(() => ({ show: showWithHide, hide }), [showWithHide, hide]);

  return (
    <ToastCommandContext.Provider value={command}>
      <ToastContext.Provider value={state}>
        {children}
        {visible && createPortal(<Toast />, document.body)}
      </ToastContext.Provider>
    </ToastCommandContext.Provider>
  );
});
```

- 얕은 비교 함수를 구현하고나서 [Zustand 코드](https://github.com/pmndrs/zustand/blob/main/src/vanilla/shallow.ts)를 살펴보았는데 Map과 Set, Symbol.iterator, 일반 객체를 분리해서 순회하는 부분을 보았습니다. 저는 따로 분리하여 처리하지 않았는데 처리하지 않았을 때 문제가 될 부분이 있을까요?

번외: 준일 코치님 멘토링 세션을 진행하며 제가 왜 빅테크를 가고 싶어하는지, 업무를 해당 회사들에 어울리는 인재처럼 진행하고 있었는지 다시 한번 돌아보게 되었습니다 감사합니다🙇‍♂️

<!--
피드백 받고 싶은 내용을 구체적으로 남겨주세요
모호한 요청은 피드백을 남기기 어렵습니다.

참고링크: https://chatgpt.com/share/675b6129-515c-8001-ba72-39d0fa4c7b62

모호한 질문의 예시)
- 무엇을 질문해야 할지 몰라서 코치님이 보시기에 고쳐야할것들 전반적으로 피드백 부탁드립니다.
- 코드 스타일에 대한 피드백 부탁드립니다.
- 코드 구조에 대한 피드백 부탁드립니다.
- 개념적인 오류에 대한 피드백 부탁드립니다.
- 추가 구현이 필요한 부분에 대한 피드백 부탁드립니다.

구체적인 질문의 예시)
- 파일A의 함수B와 그 안의 변수명을 보면 직관성이 떨어지는 것 같습니다. 함수와 변수 이름을 더 명확하게 지을 방법에 대해 조언해 주실 수 있나요?
- 현재 파일 단위로 코드를 분리했지만, 이번 주차 발제를 기준으로 봤을 때 모듈화나 계층화에서 부족함이 있는 것 같습니다. 특히 A와 B 부분에서 모듈화를 더 진행할지 그대로 둘지 고민하였습니다. (...구체적인 고민 사항 적기...). 코치님의 의견이 궁금합니다.
- 옵저버 패턴을 사용해 상태 관리 로직을 구현해 보려 했습니다. 제가 구현한 코드가 옵저버 패턴에 맞게 잘 구성되었는지 검토해 주시고, 보완할 부분을 제안해 주실 수 있을까요?
- 컴포넌트 A를 테스트 할 때 B와의 의존성 때문에 테스트 코드를 작성하려다 포기했습니다. A와 B의 의존성을 낮추고 테스트 가능성을 높이는 구조 개선 방안이 있을까요?

과제에서 디테일한 피드백을 받기 위해선 여러분의 생각을 디테일하게 표현해주셔야 한답니다.

가령, "전반적으로 이 라우터 구조가 규모가 커졌을 때 유지보수나 기능 확장에 유리한지, 아니면 리팩토링이 필요할지 조언을 받고 싶습니다" 라는 질문이 있을 때, 답변드리기가 어려워요. 
이럴 때는 "기능 확장" 상황을 먼저 가정해봐야합니다. 테스트의 엣지케이스를 작성하는 것 처럼요! 그리고 그 상황에 대해 내가 작성한 코드가 이러저러한 이유 때문에 대응가능할 것 같은데 혹시 더 고려해야할 부분이 있을지를 물어보는거죠.

이건 코치에게 이야기할 때 뿐만 아니라 팀원에게 이야기할 때에도 동일해요. 여러분의 컨텍스트를 명확하게 전달하지 않으면 여러분과 이야기할 때 시간이 무척 오래 걸린답니다.

특히 멘토링 처럼 동기적으로 이루어지는 커뮤니케이션에서는 위와 같은 질문을 던져도, 상호 피드백으로 질문을 함께 만들어갈 수 있지만, 과제 피드백 처럼 비동기 방식 + 1회용 질문일 때에는 좋은 답변을 드리기가 어려운점 인지 부탁드립니다 ㅠㅠ
-->
