### PR TITLE
[6팀 이지현] Chapter 1-3. React, Beyond the Basics 

### DIFF
--- a/packages/app/404.html
+++ b/packages/app/404.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>상품 쇼핑몰</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/src/styles.css">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: "#3b82f6",
+            secondary: "#6b7280"
+          }
+        }
+      }
+    };
+  </script>
+</head>
+<body class="bg-gray-50">
+<div id="root"></div>
+<script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/packages/app/src/components/modal/ModalProvider.tsx
+++ b/packages/app/src/components/modal/ModalProvider.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, memo, type PropsWithChildren, type ReactNode, useContext, useState } from "react";
+import { createContext, memo, type PropsWithChildren, type ReactNode, useContext, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { Modal } from "./Modal";
+import { useAutoCallback } from "@hanghae-plus/lib";
 
 export const ModalContext = createContext<{
   open: (content: ReactNode) => void;
@@ -16,12 +17,12 @@ export const useModalContext = () => useContext(ModalContext);
 export const ModalProvider = memo(({ children }: PropsWithChildren) => {
   const [content, setContent] = useState<ReactNode>(null);
 
-  const open = (newContent: ReactNode) => setContent(newContent);
+  const open = useAutoCallback((newContent: ReactNode) => setContent(newContent));
+  const close = useAutoCallback(() => setContent(null));
 
-  const close = () => setContent(null);
-
+  const value = useMemo(() => ({ open, close }), [open, close]);
   return (
-    <ModalContext value={{ open, close }}>
+    <ModalContext value={value}>
       {children}
       {content && createPortal(<Modal>{content}</Modal>, document.body)}
     </ModalContext>

--- a/packages/app/src/components/toast/ToastProvider.tsx
+++ b/packages/app/src/components/toast/ToastProvider.tsx
@@ -4,49 +4,61 @@ import { createPortal } from "react-dom";
 import { Toast } from "./Toast";
 import { createActions, initialState, toastReducer, type ToastType } from "./toastReducer";
 import { debounce } from "../../utils";
+import { useAutoCallback, useMemo } from "@hanghae-plus/lib/src/hooks";
 
 type ShowToast = (message: string, type: ToastType) => void;
 type Hide = () => void;
 
-const ToastContext = createContext<{
-  message: string;
-  type: ToastType;
+const ToastActionContext = createContext<{
   show: ShowToast;
   hide: Hide;
 }>({
-  ...initialState,
   show: () => null,
   hide: () => null,
 });
 
+const ToastStateContext = createContext<{
+  message: string;
+  type: ToastType;
+}>({
+  ...initialState,
+});
+
 const DEFAULT_DELAY = 3000;
 
-const useToastContext = () => useContext(ToastContext);
+const useToastActionContext = () => useContext(ToastActionContext);
+const useToastStateContext = () => useContext(ToastStateContext);
+
 export const useToastCommand = () => {
-  const { show, hide } = useToastContext();
+  const { show, hide } = useToastActionContext();
   return { show, hide };
 };
 export const useToastState = () => {
-  const { message, type } = useToastContext();
+  const { message, type } = useToastStateContext();
   return { message, type };
 };
 
 export const ToastProvider = memo(({ children }: PropsWithChildren) => {
   const [state, dispatch] = useReducer(toastReducer, initialState);
-  const { show, hide } = createActions(dispatch);
+  const { show, hide } = useMemo(() => createActions(dispatch), [dispatch]);
   const visible = state.message !== "";
 
-  const hideAfter = debounce(hide, DEFAULT_DELAY);
+  const hideAfter = useMemo(() => debounce(hide, DEFAULT_DELAY), [hide]);
 
-  const showWithHide: ShowToast = (...args) => {
+  const showWithHide: ShowToast = useAutoCallback((...args) => {
     show(...args);
     hideAfter();
-  };
+  });
+
+  const memodedState = useMemo(() => ({ message: state.message, type: state.type }), [state.message, state.type]);
+  const memoedAction = useMemo(() => ({ show: showWithHide, hide }), [showWithHide, hide]);
 
   return (
-    <ToastContext value={{ show: showWithHide, hide, ...state }}>
-      {children}
-      {visible && createPortal(<Toast />, document.body)}
-    </ToastContext>
+    <ToastActionContext.Provider value={memoedAction}>
+      <ToastStateContext.Provider value={memodedState}>
+        {children}
+        {visible && createPortal(<Toast />, document.body)}
+      </ToastStateContext.Provider>
+    </ToastActionContext.Provider>
   );
 });

--- a/packages/app/src/components/toast/ToastProvider.tsx
+++ b/packages/app/src/components/toast/ToastProvider.tsx
@@ -50,12 +50,11 @@ export const ToastProvider = memo(({ children }: PropsWithChildren) => {
     hideAfter();
   });
 
-  const memodedState = useMemo(() => ({ message: state.message, type: state.type }), [state.message, state.type]);
   const memoedAction = useMemo(() => ({ show: showWithHide, hide }), [showWithHide, hide]);
 
   return (
     <ToastActionContext.Provider value={memoedAction}>
-      <ToastStateContext.Provider value={memodedState}>
+      <ToastStateContext.Provider value={state}>
         {children}
         {visible && createPortal(<Toast />, document.body)}
       </ToastStateContext.Provider>

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -3,7 +3,6 @@ type Listener = () => void;
 export const createObserver = () => {
   const listeners = new Set<Listener>();
 
-  // useSyncExternalStore 에서 활용할 수 있도록 subscribe 함수를 수정합니다.
   const subscribe = (fn: Listener) => {
     listeners.add(fn);
     return () => {

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -6,6 +6,9 @@ export const createObserver = () => {
   // useSyncExternalStore 에서 활용할 수 있도록 subscribe 함수를 수정합니다.
   const subscribe = (fn: Listener) => {
     listeners.add(fn);
+    return () => {
+      unsubscribe(fn);
+    };
   };
 
   const unsubscribe = (fn: Listener) => {

--- a/packages/lib/src/createStorage.ts
+++ b/packages/lib/src/createStorage.ts
@@ -1,4 +1,5 @@
 import { createObserver } from "./createObserver.ts";
+import { shallowEquals } from "./equals/shallowEquals.ts";
 
 export const createStorage = <T>(key: string, storage = window.localStorage) => {
   let data: T | null = JSON.parse(storage.getItem(key) ?? "null");
@@ -8,6 +9,9 @@ export const createStorage = <T>(key: string, storage = window.localStorage) => 
 
   const set = (value: T) => {
     try {
+      if (shallowEquals(data, value)) {
+        return;
+      }
       data = value;
       storage.setItem(key, JSON.stringify(data));
       notify();

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -21,7 +21,7 @@ export function deepEquals(a: unknown, b: unknown): boolean {
   }
 
   for (const key of keysA) {
-    if (!keysB.includes(key)) {
+    if (!(key in b)) {
       return false;
     }
     if (!deepEquals((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])) {

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,14 +1,8 @@
-// deepEquals 함수는 두 값의 깊은 비교를 수행합니다.
 export function deepEquals(a: unknown, b: unknown): boolean {
-  // 1. 기본 타입이거나 null인 경우 처리
   if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) {
     return a === b;
   }
 
-  // 2. 둘 다 객체인 경우:
-  //    - 배열인지 확인
-  //    - 객체의 키 개수가 다른 경우 처리
-  //    - 재귀적으로 각 속성에 대해 deepEquals 호출
   if (Array.isArray(a) !== Array.isArray(b)) {
     return false;
   }

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,3 +1,33 @@
-export const deepEquals = (a: unknown, b: unknown) => {
-  return a === b;
-};
+// deepEquals 함수는 두 값의 깊은 비교를 수행합니다.
+export function deepEquals(a: unknown, b: unknown): boolean {
+  // 1. 기본 타입이거나 null인 경우 처리
+  if (typeof a !== "object" || typeof b !== "object" || a === null || b === null) {
+    return a === b;
+  }
+
+  // 2. 둘 다 객체인 경우:
+  //    - 배열인지 확인
+  //    - 객체의 키 개수가 다른 경우 처리
+  //    - 재귀적으로 각 속성에 대해 deepEquals 호출
+  if (Array.isArray(a) !== Array.isArray(b)) {
+    return false;
+  }
+
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  for (const key of keysA) {
+    if (!keysB.includes(key)) {
+      return false;
+    }
+    if (!deepEquals((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -9,15 +9,15 @@ export function shallowEquals(a: unknown, b: unknown): boolean {
     return false;
   }
   // 3. 객체의 키 개수가 다른 경우 처리
-  const kyesA = Object.keys(a);
+  const keysA = Object.keys(a);
   const keysB = Object.keys(b);
 
-  if (kyesA.length !== keysB.length) {
+  if (keysA.length !== keysB.length) {
     return false;
   }
   // 4. 모든 키에 대해 얕은 비교 수행
-  for (const key of kyesA) {
-    if (!(key in b) || (a as Record<string, unknown>)[key] !== (b as Record<string, unknown>)[key]) {
+  for (const key of keysA) {
+    if (!(key in b) || !Object.is((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])) {
       return false;
     }
   }

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,3 +1,25 @@
-export const shallowEquals = (a: unknown, b: unknown) => {
-  return a === b;
-};
+// shallowEquals 함수는 두 값의 얕은 비교를 수행합니다.
+export function shallowEquals(a: unknown, b: unknown): boolean {
+  // 1. 두 값이 정확히 같은지 확인 (참조가 같은 경우)
+  if (a === b) {
+    return true;
+  }
+  // 2. 둘 중 하나라도 객체가 아닌 경우 처리
+  if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) {
+    return false;
+  }
+  // 3. 객체의 키 개수가 다른 경우 처리
+  const kyesA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  if (kyesA.length !== keysB.length) {
+    return false;
+  }
+  // 4. 모든 키에 대해 얕은 비교 수행
+  for (const key of kyesA) {
+    if (!(key in b) || (a as Record<string, unknown>)[key] !== (b as Record<string, unknown>)[key]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,21 +1,19 @@
-// shallowEquals 함수는 두 값의 얕은 비교를 수행합니다.
 export function shallowEquals(a: unknown, b: unknown): boolean {
-  // 1. 두 값이 정확히 같은지 확인 (참조가 같은 경우)
   if (a === b) {
     return true;
   }
-  // 2. 둘 중 하나라도 객체가 아닌 경우 처리
+
   if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) {
     return false;
   }
-  // 3. 객체의 키 개수가 다른 경우 처리
+
   const keysA = Object.keys(a);
   const keysB = Object.keys(b);
 
   if (keysA.length !== keysB.length) {
     return false;
   }
-  // 4. 모든 키에 대해 얕은 비교 수행
+
   for (const key of keysA) {
     if (!(key in b) || !Object.is((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])) {
       return false;

--- a/packages/lib/src/hocs/deepMemo.ts
+++ b/packages/lib/src/hocs/deepMemo.ts
@@ -2,9 +2,6 @@ import type { FunctionComponent } from "react";
 import { memo } from "./memo.ts";
 import { deepEquals } from "../equals";
 
-// deepMemo HOC는 컴포넌트의 props를 깊은 비교하여 불필요한 리렌더링을 방지합니다.
-// deepEquals 함수를 사용하여 props 비교
-// 앞에서 만든 memo를 사용
 export function deepMemo<P extends object>(Component: FunctionComponent<P>) {
   return memo(Component, deepEquals);
 }

--- a/packages/lib/src/hocs/deepMemo.ts
+++ b/packages/lib/src/hocs/deepMemo.ts
@@ -1,5 +1,10 @@
 import type { FunctionComponent } from "react";
+import { memo } from "./memo.ts";
+import { deepEquals } from "../equals";
 
+// deepMemo HOC는 컴포넌트의 props를 깊은 비교하여 불필요한 리렌더링을 방지합니다.
+// deepEquals 함수를 사용하여 props 비교
+// 앞에서 만든 memo를 사용
 export function deepMemo<P extends object>(Component: FunctionComponent<P>) {
-  return Component;
+  return memo(Component, deepEquals);
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -1,6 +1,25 @@
-import { type FunctionComponent } from "react";
+import { type FunctionComponent, type ReactNode } from "react";
 import { shallowEquals } from "../equals";
 
+interface Memoed<P> {
+  props: P | undefined;
+  result: ReactNode | Promise<ReactNode>;
+}
+
+// memo HOC는 컴포넌트의 props를 얕은 비교하여 불필요한 리렌더링을 방지합니다.
 export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
-  return Component;
+  // 1. 이전 props를 저장할 ref 생성
+  // 2. 메모이제이션된 컴포넌트 생성
+  const memoed: Memoed<P> = {} as Memoed<P>;
+
+  return function MemoizedComponent(props: P) {
+    // 3. equals 함수를 사용하여 props 비교
+    if (memoed.props !== undefined && equals(memoed.props, props)) {
+      return memoed.result;
+    }
+    // 4. props가 변경된 경우에만 새로운 렌더링 수행
+    memoed.props = props;
+    memoed.result = Component(props);
+    return memoed.result;
+  };
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -6,18 +6,14 @@ interface Memoed<P> {
   result: ReactNode | Promise<ReactNode>;
 }
 
-// memo HOC는 컴포넌트의 props를 얕은 비교하여 불필요한 리렌더링을 방지합니다.
 export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
-  // 1. 이전 props를 저장할 ref 생성
-  // 2. 메모이제이션된 컴포넌트 생성
   const memoed: Memoed<P> = {} as Memoed<P>;
 
   return function MemoizedComponent(props: P) {
-    // 3. equals 함수를 사용하여 props 비교
     if (memoed.props !== undefined && equals(memoed.props, props)) {
       return memoed.result;
     }
-    // 4. props가 변경된 경우에만 새로운 렌더링 수행
+
     memoed.props = props;
     memoed.result = Component(props);
     return memoed.result;

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -2,7 +2,6 @@ import type { AnyFunction } from "../types";
 import { useCallback } from "./useCallback";
 import { useRef } from "./useRef";
 
-// useCallback과 useRef를 이용하여 useAutoCallback
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
   const ref = useRef(fn);
   ref.current = fn;

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -2,6 +2,14 @@ import type { AnyFunction } from "../types";
 import { useCallback } from "./useCallback";
 import { useRef } from "./useRef";
 
+// useCallback과 useRef를 이용하여 useAutoCallback
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
-  return fn;
+  const ref = useRef(fn);
+  ref.current = fn;
+
+  const callback = useCallback((...args: Parameters<T>): ReturnType<T> => {
+    return ref.current(...args);
+  }, []);
+
+  return callback as T;
 };

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
 import type { DependencyList } from "react";
+import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
   // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  return useMemo(() => factory, _deps);
 }

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,8 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
+/* eslint-disable react-hooks/exhaustive-deps */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import type { DependencyList } from "react";
 import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
-  // 직접 작성한 useMemo를 통해서 만들어보세요.
   return useMemo(() => factory, _deps);
 }

--- a/packages/lib/src/hooks/useDeepMemo.ts
+++ b/packages/lib/src/hooks/useDeepMemo.ts
@@ -4,6 +4,5 @@ import { useMemo } from "./useMemo";
 import { deepEquals } from "../equals";
 
 export function useDeepMemo<T>(factory: () => T, deps: DependencyList): T {
-  // 직접 작성한 useMemo를 참고해서 만들어보세요.
   return useMemo(factory, deps, deepEquals);
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import type { DependencyList } from "react";
 import { shallowEquals } from "../equals";
 import { useRef } from "./useRef";
@@ -8,16 +7,19 @@ export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = sh
   // 직접 작성한 useRef를 통해서 만들어보세요! 이게 제일 중요합니다.
 
   // 1. 이전 의존성과 결과를 저장할 ref 생성
-  const ref = useRef<DependencyList>(_deps);
-  const memoFunction = useRef<T | null>(null);
+  const ref = useRef<{ value: T; deps: DependencyList } | null>(null);
 
+  if (!ref.current) {
+    ref.current = { value: factory(), deps: _deps };
+    return ref.current.value;
+  }
   // 2. 현재 의존성과 이전 의존성 비교
 
   // 3. 의존성이 변경된 경우 factory 함수 실행 및 결과 저장
-  if (!_equals(ref.current, _deps) || memoFunction.current === null) {
-    memoFunction.current = factory();
-    ref.current = _deps;
+  if (!_equals(ref.current.deps, [..._deps])) {
+    ref.current.value = factory();
+    ref.current.deps = _deps;
   }
   // 4. 메모이제이션된 값 반환
-  return memoFunction.current;
+  return ref.current.value;
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -1,8 +1,23 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { DependencyList } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "./useRef";
 
+// useMemo 훅은 계산 비용이 높은 값을 메모이제이션합니다.
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+  // 직접 작성한 useRef를 통해서 만들어보세요! 이게 제일 중요합니다.
+
+  // 1. 이전 의존성과 결과를 저장할 ref 생성
+  const ref = useRef<DependencyList>(_deps);
+  const memoFunction = useRef<T | null>(null);
+
+  // 2. 현재 의존성과 이전 의존성 비교
+
+  // 3. 의존성이 변경된 경우 factory 함수 실행 및 결과 저장
+  if (!_equals(ref.current, _deps) || memoFunction.current === null) {
+    memoFunction.current = factory();
+    ref.current = _deps;
+  }
+  // 4. 메모이제이션된 값 반환
+  return memoFunction.current;
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -2,24 +2,18 @@ import type { DependencyList } from "react";
 import { shallowEquals } from "../equals";
 import { useRef } from "./useRef";
 
-// useMemo 훅은 계산 비용이 높은 값을 메모이제이션합니다.
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요! 이게 제일 중요합니다.
-
-  // 1. 이전 의존성과 결과를 저장할 ref 생성
   const ref = useRef<{ value: T; deps: DependencyList } | null>(null);
 
   if (!ref.current) {
     ref.current = { value: factory(), deps: _deps };
     return ref.current.value;
   }
-  // 2. 현재 의존성과 이전 의존성 비교
 
-  // 3. 의존성이 변경된 경우 factory 함수 실행 및 결과 저장
   if (!_equals(ref.current.deps, [..._deps])) {
     ref.current.value = factory();
     ref.current.deps = _deps;
   }
-  // 4. 메모이제이션된 값 반환
+
   return ref.current.value;
 }

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,4 +1,11 @@
+import { useState } from "react";
+
+// useRef 훅은 렌더링 사이에 값을 유지하는 가변 ref 객체를 생성합니다.
 export function useRef<T>(initialValue: T): { current: T } {
   // useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  const [refObejct] = useState(() => ({
+    current: initialValue,
+  }));
+
+  return refObejct;
 }

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,8 +1,6 @@
 import { useState } from "react";
 
-// useRef 훅은 렌더링 사이에 값을 유지하는 가변 ref 객체를 생성합니다.
 export function useRef<T>(initialValue: T): { current: T } {
-  // useState를 이용해서 만들어보세요.
   const [refObejct] = useState(() => ({
     current: initialValue,
   }));

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -8,5 +8,5 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 export const useRouter = <T extends RouterInstance<AnyFunction>, S>(router: T, selector = defaultSelector<T, S>) => {
   // useSyncExternalStore를 사용하여 router의 상태를 구독하고 가져오는 훅을 구현합니다.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(router);
+  return useSyncExternalStore(router.subscribe, () => shallowSelector(router));
 };

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -6,7 +6,6 @@ import { useShallowSelector } from "./useShallowSelector";
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 
 export const useRouter = <T extends RouterInstance<AnyFunction>, S>(router: T, selector = defaultSelector<T, S>) => {
-  // useSyncExternalStore를 사용하여 router의 상태를 구독하고 가져오는 훅을 구현합니다.
   const shallowSelector = useShallowSelector(selector);
   return useSyncExternalStore(router.subscribe, () => shallowSelector(router));
 };

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -5,5 +5,9 @@ type Selector<T, S = T> = (state: T) => S;
 
 export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
   // 이전 상태를 저장하고, shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
-  return (state: T): S => selector(state);
+  const prev = useRef<S>(undefined);
+  return (state: T): S => {
+    const next = selector(state);
+    return shallowEquals(prev.current, next) ? (prev.current as S) : (prev.current = next);
+  };
 };

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -4,7 +4,6 @@ import { shallowEquals } from "../equals";
 type Selector<T, S = T> = (state: T) => S;
 
 export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
-  // 이전 상태를 저장하고, shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
   const prev = useRef<S>(undefined);
   return (state: T): S => {
     const next = selector(state);

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,7 +1,20 @@
 import { useState } from "react";
 import { shallowEquals } from "../equals";
+import { useCallback } from "./useCallback";
 
-export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
+export const useShallowState = <T>(initialValue: T | (() => T)) => {
   // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
-  return useState(initialValue);
+
+  const [state, setSTate] = useState(() => initialValue);
+
+  const compareState = useCallback((newState: T | (() => T)) => {
+    setSTate((prevState) => {
+      if (!shallowEquals(prevState, newState)) {
+        return newState;
+      }
+      return prevState;
+    });
+  }, []);
+
+  return [state, compareState];
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -3,8 +3,6 @@ import { shallowEquals } from "../equals";
 import { useCallback } from "./useCallback";
 
 export const useShallowState = <T>(initialValue: T | (() => T)) => {
-  // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
-
   const [state, setSTate] = useState(() => initialValue);
 
   const compareState = useCallback((newState: T | (() => T)) => {

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -5,5 +5,5 @@ type Storage<T> = ReturnType<typeof createStorage<T>>;
 
 export const useStorage = <T>(storage: Storage<T>) => {
   // useSyncExternalStore를 사용해서 storage의 상태를 구독하고 가져오는 훅을 구현해보세요.
-  return storage.get();
+  return useSyncExternalStore(storage.subscribe, storage.get);
 };

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -4,6 +4,5 @@ import type { createStorage } from "../createStorage";
 type Storage<T> = ReturnType<typeof createStorage<T>>;
 
 export const useStorage = <T>(storage: Storage<T>) => {
-  // useSyncExternalStore를 사용해서 storage의 상태를 구독하고 가져오는 훅을 구현해보세요.
   return useSyncExternalStore(storage.subscribe, storage.get);
 };

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -9,5 +9,6 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 export const useStore = <T, S = T>(store: Store<T>, selector: (state: T) => S = defaultSelector<T, S>) => {
   // useSyncExternalStore와 useShallowSelector를 사용해서 store의 상태를 구독하고 가져오는 훅을 구현해보세요.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(store.getState());
+
+  return useSyncExternalStore(store.subscribe, () => shallowSelector(store.getState()));
 };

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -7,7 +7,6 @@ type Store<T> = ReturnType<typeof createStore<T>>;
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 
 export const useStore = <T, S = T>(store: Store<T>, selector: (state: T) => S = defaultSelector<T, S>) => {
-  // useSyncExternalStore와 useShallowSelector를 사용해서 store의 상태를 구독하고 가져오는 훅을 구현해보세요.
   const shallowSelector = useShallowSelector(selector);
 
   return useSyncExternalStore(store.subscribe, () => shallowSelector(store.getState()));


### PR DESCRIPTION
## 과제 체크포인트

### 배포 링크
- https://j2h30728.github.io/front_6th_chapter1-3/
<!--
배포 링크를 적어주세요
예시: https://<username>.github.io/front-6th-chapter1-3/

배포가 완료되지 않으면 과제를 통과할 수 없습니다.
배포 후에 정상 작동하는지 확인해주세요.
-->

### 기본과제

#### equalities

- [x] shallowEquals 구현 완료
- [x] deepEquals 구현 완료

#### hooks

- [x] useRef 구현 완료
- [x] useMemo 구현 완료
- [x] useCallback 구현 완료
- [x] useDeepMemo 구현 완료
- [x] useShallowState 구현 완료
- [x] useAutoCallback 구현 완료

#### High Order Components

- [x] memo 구현 완료
- [x] deepMemo 구현 완료

### 심화 과제

#### hooks

- [x] createObserver를 useSyncExternalStore에 사용하기 적합한 코드로 개선
- [x] useShallowSelector 구현
- [x] useStore 구현
- [x] useRouter 구현
- [x] useStorage 구현

### context

- [x] ToastContext, ModalContext 개선

## 과제 셀프회고

<!-- 과제에 대한 회고를 작성해주세요 -->

### 기술적 성장

<!-- 예시
- 새로 학습한 개념
- 기존 지식의 재발견/심화
- 구현 과정에서의 기술적 도전과 해결
-->
#### useState로 useRef를 만들 수도 있다.

계속 전역변수로 값을 유지하려는 방법으로만 생각하려 했기에, 레퍼런스를 얻고자 오픈소스 라이브러리를 찾아봤었습니다.  
하지만, react의 useRef 내부구현은 생각보다 이해하기 어려웠었습니다.

preact의 경우에는 저희 과제는 useRef를 사용해 useMemo를 만들기 때문에 다소 당황스럽기도 했습니다.

```ts
// react
export function useRef<T>(initialValue: T): {current: T} {
  const dispatcher = resolveDispatcher();
  return dispatcher.useRef(initialValue);
}

// 내부 구현 
// 첫 렌더링시에는 초기 값을 저장하는 로직
function mountRef<T>(initialValue: T): {current: T} {
  const hook = mountWorkInProgressHook();
  const ref = {current: initialValue}; // ref에 저장
  hook.memoizedState = ref; 
  return ref;
}

// 두 번쨰 렌더링 부터는 저장한 값만 가져오는 로직
function updateRef<T>(initialValue: T): {current: T} {
  const hook = updateWorkInProgressHook(); 
  return hook.memoizedState; 
}

```

```ts
// preact
/** @type {(initialValue: unknown) => unknown} */
export function useRef(initialValue) {
	currentHook = 5;
	return useMemo(() => ({ current: initialValue }), []);
}
```
과제 요구사항 중 주석으로 useState를 활용하는 힌트를 가지고 다시 확장된 사고를 이어갔습니다. useState의 인자에 함수를 넣으면 최초렌더링시에 한 번 만 실행하는 것을 생각해냈습니다.

useState의 인자에 함수를 넣으면 최초 렌더링 시에만 실행되는 특성을 활용해, 참조 타입 객체를 state로 저장하여 메모리 주소값을 고정시키고, setter 함수 없이 state 객체에 직접 접근하는 방식으로 구현했습니다.

그리고 리액트 내부 코드를 들여다보니 이전에 확인했던 useRef 구현체가 조금이나마 이해할 수 있었습니다.
useState는 initailState가 함수타입이라면 실행시켜서 hook.memoizedState에 저장하는 것과 useRef에서 직접 {current: initialValue} 로 current 값을 저장하는 유사점을 확인 할 수 있었습니다.

```ts
// 실제 첫 렌더링 시에 useState 내부에서 실행되는 함수
function mountState<S>(
  initialState: (() => S) | S,
): [S, Dispatch<BasicStateAction<S>>] {
  const hook = mountStateImpl(initialState);
  const queue = hook.queue;
  const dispatch: Dispatch<BasicStateAction<S>> = (dispatchSetState.bind(
    null,
    currentlyRenderingFiber,
    queue,
  ): any);
  queue.dispatch = dispatch;
  return [hook.memoizedState, dispatch];
}

function mountStateImpl<S>(initialState: (() => S) | S): Hook {
  const hook = mountWorkInProgressHook();
  if (typeof initialState === 'function') { // useState 상태 초기값이 함수일 때
    const initialStateInitializer = initialState;
    initialState = initialStateInitializer(); 
    
    // 중략
    }
  }
  hook.memoizedState = hook.baseState = initialState;  // 함수 실행한 초기상태 값 
  const queue: UpdateQueue<S, BasicStateAction<S>> = {
    pending: null,
    lanes: NoLanes,
    dispatch: null,
    lastRenderedReducer: basicStateReducer,
    lastRenderedState: (initialState: any),
  };
  hook.queue = queue;
  return hook;
}
```

#### `Object.is`와 `===`

기존에는 일치 연산자(`===`)를 관성적으로 사용했었는데, 이번 과제를 통해 Object.is의 특성과 리액트에서의 활용 맥락을 더 깊이 이해하게 되었습니다.

```ts
// packages/lib/src/equals/shallowEquals.ts
// before
  // 4. 모든 키에 대해 얕은 비교 수행
  for (const key of kyesA) {
    if (!(key in b) || (a as Record<string, unknown>)[key] !== (b as Record<string, unknown>)[key]) {
      return false;
    }

// after
  for (const key of keysA) {
    if (!(key in b) || !Object.is((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key])) {
      return false;
    }
```

NaN, +0, -0 등의 특수 케이스를 정확하게 다루기 위해 Object.is를 사용하도록 리팩토링했으며, 얕은 비교 함수가 리액트의 의존성 배열 비교 로직과 별개로 동작한다는 점도 명확하게 이해할 수 있었습니다.


#### 리액트 프로파일러

ToastProvider, ModalProvider 최적화 과제를 수행하면서 리액트 프로파일러를 본격적으로 활용했습니다. 
어떤 트리거에서 어떤 렌더링이 일어나는지, 어떤 부분을 메모이제이션하면 리렌더링을 방지할 수 있는지를 시각적으로 파악할 수 있어 매우 유용했습니다.


### 자랑하고 싶은 코드

<!-- 예시
- 특히 만족스러운 구현
- 리팩토링이 필요한 부분
- 코드 설계 관련 고민과 결정
-->

useState를 활용한 useRef 구현이 가장 만족스러웠습니다. 
처음에는 전역 상태 관리 방식으로만 접근하려 했었고, useState 힌트조차 이해하지 못했었습니다. 
하지만 결국 useState의 기능과 원리를 다시 복습하며 완성한 코드라서 특별한 의미가 있습니다.

```ts
export function useRef<T>(initialValue: T): { current: T } {
  const [refObejct] = useState(() => ({
    current: initialValue,
  }));
  
  return refObejct;
}
```


### 개선이 필요하다고 생각하는 코드

<!-- 예시
- 특히 만족스러운 구현
- 리팩토링이 필요한 부분
- 코드 설계 관련 고민과 결정
-->

ToastProvider에서 상태와 액션 프로바이더를 분리하면서 복잡도가 높아진 것 같은 기분이 듭니다.  기분이...


### 학습 효과 분석

<!-- 예시
- 가장 큰 배움이 있었던 부분
- 추가 학습이 필요한 영역
- 실무 적용 가능성
-->

#### 실무 관련 내용
현재 디자인 시스템 컴포넌트 개발에서 컴파운드 컴포넌트 패턴과 Context API를 자주 사용하고 있습니다. 
이번 3주차 과제를 통해 어떤 값을 메모이제이션해야 하는지, 어디에 집중해야 하는지에 대한 방향의 이정표가 될 수 있었습니다.

같은 날 업무로 아코디언 컴포넌트를 개발했는데, 멀티 아코디언이 아닌 이상 특정 인터랙션에 하나의 아코디언 컴포넌트만 리렌더링 되는 게 자연스러워, 무분별한 메모이제이션이 오히려 불필요할 수 있다는 점을 깨달았습니다.

그동안 관성적으로 메모이제이션을 사용해왔을 가능성이 있지만, 이번 경험을 계기로 메모이제이션이 실제 유의미한 상황인지 프로파일링과 함께 고민할 수 있었습니다.

#### 가장 큰 배움이 있었던 부분

사실, react 라이브러리의 내부 구현을 찾아볼 때 다음과 같은 코드를 만나면 더 이상 찾아보려 하지 않았었습니다.
```tsx
import * as React from 'react';

const ReactSharedInternals =
  React.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;

export default ReactSharedInternals;
```
하지만 이번 과제를 계기로 **"다른 개발자들은 어떻게 내부 구현을 추적하고 분석하는가?"**에 대한 궁금증이 생겼습니다.
여러 블로그와 자료를 찾아보며 코드 흐름을 따라가는 방법들도 함께 학습할 수 있었습니다.

### 과제 피드백

<!-- 예시
- 과제에서 모호하거나 애매했던 부분
- 과제에서 좋았던 부분
-->

진행한 과제 중 3주차 요구사항이 가장 친절하고 재미있었습니다. 
덕분에 오픈소스 라이브러리 코드를 확인해보는 시간을 가질 수 있어서 부가적인 학습 효과까지 얻을 수 있었습니다.


## 학습 갈무리

### 리액트의 렌더링이 어떻게 이루어지는지 정리해주세요.

<!-- 예시
- 리액트의 렌더링 과정
- 리액트의 렌더링 최적화 방법
- 리액트의 렌더링과 관련된 개념들 (예: Virtual DOM, Reconciliation 등)
- 리액트의 렌더링과 관련된 라이프사이클 메서드
- 리액트의 렌더링과 관련된 Hooks (예: useMemo, useCallback 등)
-->

#### 리액트 렌더링 과정

1) 트리거(Trigger): 렌더링 시작 신호

- 상태(state)나 props가 변경될 때, 혹은 **`ReactDOM.createRoot(...).render(<App />)`** 코드처럼 최초 마운트 시 렌더링이 시작됩니다.
- 여러 상태 변화를 한 번에 처리하는 Batching 기법이 적용되어, 실제로는 한 번만 렌더링됩니다.
- React 18부터는 비동기 콜백 내부에서 발생하는 여러 렌더링 트리거도 한 번에 묶어 처리할 수 있게 개선되었습니다.

2) Render 단계: 가상 DOM 생성 및 준비

- JSX 문법을 통해 만들어진 UI 구조는 내부적으로 JS 객체(React Element)로 변환됩니다.
- 실제 DOM 대신 Virtual DOM(가상 DOM)이라는 메모리 내 구조가 만들어집니다.
- Virtual DOM상에 Fiber라는 단위 객체가 각 컴포넌트별로 생성되어, 상태, 이펙트, 업데이트 정보 등을 보관합니다.

3) Reconciliation(재조정): 변화점 감지

- 새롭게 만들어진 Virtual DOM 트리와 직전의 트리를 비교(diffing)합니다.
- 변화가 필요한 부분만 찾아내기 위해 key 등 휴리스틱 알고리즘을 사용, 성능을 O(n)까지 최적화합니다.
- 변경이 발생한 요소만 선별해 실제 DOM 변경이 이루어지도록 준비합니다.

4) Commit 단계

- 변화가 감지된 부분만 실제 DOM에 반영합니다.
- 이 시점에 컴포넌트의 생명주기 메서드(`componentDidMount`, `componentDidUpdate`, `componentWillUnmount` 등) 또는 함수형 컴포넌트의 이펙트 훅(`useEffect`, `useLayoutEffect` 등)이 실행됩니다.

##### 렌더링 최적화 방법

- **memo** : 동일한 props에 대해 불필요한 컴포넌트 리렌더링 방지합니다.
- **커스텀훅 `useMemo`와 `useCallback`**: 값 또는 함수를 메모이제이션하여 무거운 새로운계산 및 재생성을 방지합니다.
- **index가 아닌 key 사용**: 리스트 컴포넌트에서 알맞은 key을 지정할 경우에 diff 알고리즘의 효율을 높일 수 있습니다. index를 사용할 경우에는 순서가 바뀌거나 리스트 아이템이 바뀔 경우에 알아채지 못하게 되어 효율성이 저하됩니다.
- 상태 관리: 자주 변경되는 상태와 그렇지 않은 상태를 분리하고, 전역 상태보다는 지역 상태를 사용하는 것으로 사이드 이펙트로 인한 리렌더링을 줄입니다.


### 메모이제이션에 대한 나의 생각을 적어주세요.

<!-- 예시
- 메모이제이션이 언제 필요할까?
- 메모이제이션을 사용하지 않으면 어떤 문제가 발생할까?
- 메모이제이션을 사용했을 때의 장점과 단점은 무엇일까?
- 메모이제이션을 사용하지 않고도 해결할 수 있는 방법은 무엇일까?
-->

커스텀훅을 만들 때, 해당 훅이 실제로 어디서 어떻게 사용될지 모르기 때문에 보통 외부로 내보내는 함수는 `useCallback`으로 감싸서 `export`하려고 합니다. 
실제로 prop으로 핸들러 함수가 내려가는 경우, 이 참조가 바뀔 때마다 하위 컴포넌트가 불필요하게 리렌더링되는 현상을 방지하는 용도로 많이 쓰게 됩니다.

또한, 데이터(리스트 등)가 변경되지 않으면 `React.memo`나 `useMemo`를 활용해서 컴포넌트나 연산 결과를 캐싱하는 경험도 자주 했습니다.
복잡하거나 연산 비용이 비싼 작업이 반복될 경우에도 useMemo로 값을 캐싱해 연산 횟수를 줄입니다.

UI에서 리렌더링이 자주 일어나서 성능에 영향을 줄 수 있는 상황에는 `useMemo` 혹은 `useCallback`으로 불필요한 재계산과 리렌더를 최소화하려고 노력합니다.

대신, 필요 이상으로 메모이제이션을 남용하는 것은 오히려 코드의 복잡도만 올릴 수 있으니, 가능하면 상태나 함수를 외부 모듈로 분리하여 참조가 바뀌지 않게 설계하거나, 상태 분리로 리렌더링 범위를 최대한 좁히는 것에도 신경씁니다.


### 컨텍스트와 상태관리에 대한 나의 생각을 적어주세요.

<!-- 예시
- 컨텍스트와 상태관리가 필요한 이유는 무엇일까?
- 컨텍스트와 상태관리를 사용하지 않으면 어떤 문제가 발생할까?
- 컨텍스트와 상태관리를 사용했을 때의 장점과 단점은 무엇일까?
- 컨텍스트와 상태관리를 사용하지 않고도 해결할 수 있는 방법은 무엇일까?
- 컨텍스트와 상태관리를 사용할 때 주의해야 할 점은 무엇일까?
-->

3주차 발제 시간 후 팀별 활동에서 *`주제3` Context와 전역상태 라이브러리의 차이점은 뭘까요?* 에 대해서 이야기를 나누게 되었었습니다.

당시에는 저는 이렇게 작성했었습니다.

> 이지현: context는 상태를 공유하고싶은 원하는 범위가 명확하거나 **프롭드릴링**을 해소하기 위해 사용합니다. 
> 전역상태 라이브러리의 경우에는 사용 범위가 프로젝트 전체 단위로 광범위적일 때 많이 사용하고 있습니다.
> 

대체로 contextAPI로는 컴파운드 컴포넌트를 만들 때 자주 활용했습니다. 
이때까지의 경험기반으로 작성하고 이야기를 했었는데 과제를 하면서 또 다른 생각을 가지게 되었습니다.

ToastProvider 같은 리렌더링에 민감한 케이스에서 `contextAPI`만으로는 성능 최적화가 까다롭다는 걸 새삼 느꼈습니다. 
특히 state와 action 분리, provider value의 메모이제이션, 관련 함수들의 useCallback 처리 등 수동 최적화 작업이 상당히 많다는 것을 경험했습니다.

이 과정을 겪으면서, 그동안 `useMemo`, `useCallback`을 습관적으로 사용해왔고 실제 리렌더링 여부를 프로파일링하지 않았다는 반성도 하게 됐습니다. 

이러한 작업을 진행하다보니, 리렌더링에 민감한 케이스라면 `contextAPI` 보다는 상태 관리 라이브러리를 사용하여 성능 최적화 및 개발 편의성까지 동시에 고려하는 것도 더 좋은 선택일 수 있겠다는 생각이 들었습니다



## 리뷰 받고 싶은 내용

<!--
피드백 받고 싶은 내용을 구체적으로 남겨주세요
모호한 요청은 피드백을 남기기 어렵습니다.

참고링크: https://chatgpt.com/share/675b6129-515c-8001-ba72-39d0fa4c7b62

모호한 질문의 예시)
- 무엇을 질문해야 할지 몰라서 코치님이 보시기에 고쳐야할것들 전반적으로 피드백 부탁드립니다.
- 코드 스타일에 대한 피드백 부탁드립니다.
- 코드 구조에 대한 피드백 부탁드립니다.
- 개념적인 오류에 대한 피드백 부탁드립니다.
- 추가 구현이 필요한 부분에 대한 피드백 부탁드립니다.

구체적인 질문의 예시)
- 파일A의 함수B와 그 안의 변수명을 보면 직관성이 떨어지는 것 같습니다. 함수와 변수 이름을 더 명확하게 지을 방법에 대해 조언해 주실 수 있나요?
- 현재 파일 단위로 코드를 분리했지만, 이번 주차 발제를 기준으로 봤을 때 모듈화나 계층화에서 부족함이 있는 것 같습니다. 특히 A와 B 부분에서 모듈화를 더 진행할지 그대로 둘지 고민하였습니다. (...구체적인 고민 사항 적기...). 코치님의 의견이 궁금합니다.
- 옵저버 패턴을 사용해 상태 관리 로직을 구현해 보려 했습니다. 제가 구현한 코드가 옵저버 패턴에 맞게 잘 구성되었는지 검토해 주시고, 보완할 부분을 제안해 주실 수 있을까요?
- 컴포넌트 A를 테스트 할 때 B와의 의존성 때문에 테스트 코드를 작성하려다 포기했습니다. A와 B의 의존성을 낮추고 테스트 가능성을 높이는 구조 개선 방안이 있을까요?

과제에서 디테일한 피드백을 받기 위해선 여러분의 생각을 디테일하게 표현해주셔야 한답니다.

가령, "전반적으로 이 라우터 구조가 규모가 커졌을 때 유지보수나 기능 확장에 유리한지, 아니면 리팩토링이 필요할지 조언을 받고 싶습니다" 라는 질문이 있을 때, 답변드리기가 어려워요. 
이럴 때는 "기능 확장" 상황을 먼저 가정해봐야합니다. 테스트의 엣지케이스를 작성하는 것 처럼요! 그리고 그 상황에 대해 내가 작성한 코드가 이러저러한 이유 때문에 대응가능할 것 같은데 혹시 더 고려해야할 부분이 있을지를 물어보는거죠.

이건 코치에게 이야기할 때 뿐만 아니라 팀원에게 이야기할 때에도 동일해요. 여러분의 컨텍스트를 명확하게 전달하지 않으면 여러분과 이야기할 때 시간이 무척 오래 걸린답니다.

특히 멘토링 처럼 동기적으로 이루어지는 커뮤니케이션에서는 위와 같은 질문을 던져도, 상호 피드백으로 질문을 함께 만들어갈 수 있지만, 과제 피드백 처럼 비동기 방식 + 1회용 질문일 때에는 좋은 답변을 드리기가 어려운점 인지 부탁드립니다 ㅠㅠ
-->

- ** contextAPI를 활용한 코드를 작성하다보면 어떻게 파일 및 코드 분리를 해놓을지 고민이 되기도합니다.**
    
    예를들면, 컴파운트 컴포넌트를 만들다고 했을때 context provider와 다른요소들을 한 파일에 둘지 하나의 폴더에 하위 파일로 요소마다 분리할지 고민입니다. 이 부분은 주관이기도 하고 컨벤션이기도 하지만, 만약 컨벤션이 없는 상황이라면 코치님은 어떻게 하시는지 궁금합니다.
    
- **Object.is와 shallowEquals를 보면서 궁금했던 부분이 있습니다.**
    
    상태저장소를 만드는 createStore에서는 Object.is사용하여 빠른 최적화과 함께 참조값을 비교하여 상태를 업데이트하고있습니다. 이는 리액트내부에서 dispatch가 빈번하게 발생할 수도 있다는 관점으로 생각하면 합리적이라고 생각합니다. 
    그렇다면 store보다는 set하는 빈도수가 적게 사용할 것 같은 createStorage는 shallowEquals를 사용하여 얕은 비교까지 하여 업데이트하는 방식으로 최적화하는 것에 대해서는 어떻게 생각하시나요? 이 또한, 어떤 대량의 데이터가 저장될지 모르니 Object.is가 더 괜찮은 선택일까요?
