### PR TITLE
[5팀 허정석] Chapter 1-3. React, Beyond the Basics

### DIFF
--- a/packages/app/src/components/toast/ToastProvider.tsx
+++ b/packages/app/src/components/toast/ToastProvider.tsx
@@ -4,49 +4,56 @@ import { createPortal } from "react-dom";
 import { Toast } from "./Toast";
 import { createActions, initialState, toastReducer, type ToastType } from "./toastReducer";
 import { debounce } from "../../utils";
+import { useCallback, useMemo } from "@hanghae-plus/lib/src/hooks";
 
 type ShowToast = (message: string, type: ToastType) => void;
 type Hide = () => void;
-
-const ToastContext = createContext<{
+// Context 분리
+// 상태 Context
+const ToastStateContext = createContext<{
   message: string;
   type: ToastType;
-  show: ShowToast;
-  hide: Hide;
-}>({
-  ...initialState,
+}>({ ...initialState });
+// 이벤트 Context
+const ToastCommandContext = createContext<{ show: ShowToast; hide: Hide }>({
   show: () => null,
   hide: () => null,
 });
 
 const DEFAULT_DELAY = 3000;
-
-const useToastContext = () => useContext(ToastContext);
-export const useToastCommand = () => {
-  const { show, hide } = useToastContext();
-  return { show, hide };
-};
-export const useToastState = () => {
-  const { message, type } = useToastContext();
-  return { message, type };
-};
+// Hook 수정
+export const useToastCommand = () => useContext(ToastCommandContext);
+export const useToastState = () => useContext(ToastStateContext);
 
 export const ToastProvider = memo(({ children }: PropsWithChildren) => {
   const [state, dispatch] = useReducer(toastReducer, initialState);
-  const { show, hide } = createActions(dispatch);
+  const { show, hide } = useMemo(() => createActions(dispatch), [dispatch]);
   const visible = state.message !== "";
-
-  const hideAfter = debounce(hide, DEFAULT_DELAY);
-
-  const showWithHide: ShowToast = (...args) => {
-    show(...args);
-    hideAfter();
-  };
-
+  // 메모이제이션
+  const hideAfter = useMemo(() => debounce(hide, DEFAULT_DELAY), [hide]);
+  // 메모이제이션
+  const showWithHide: ShowToast = useCallback(
+    (...args) => {
+      show(...args);
+      hideAfter();
+    },
+    [show, hideAfter],
+  );
+  // props 로 넘길 값 (메모이제이션)
+  const commandValue = useMemo(
+    () => ({
+      show: showWithHide,
+      hide: hide,
+    }),
+    [showWithHide, hide],
+  );
   return (
-    <ToastContext value={{ show: showWithHide, hide, ...state }}>
-      {children}
-      {visible && createPortal(<Toast />, document.body)}
-    </ToastContext>
+    // Provider 중첩
+    <ToastCommandContext.Provider value={commandValue}>
+      <ToastStateContext.Provider value={state}>
+        {children}
+        {visible && createPortal(<Toast />, document.body)}
+      </ToastStateContext.Provider>
+    </ToastCommandContext.Provider>
   );
 });

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -6,6 +6,7 @@ export const createObserver = () => {
   // useSyncExternalStore 에서 활용할 수 있도록 subscribe 함수를 수정합니다.
   const subscribe = (fn: Listener) => {
     listeners.add(fn);
+    return () => unsubscribe(fn);
   };
 
   const unsubscribe = (fn: Listener) => {

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,3 +1,30 @@
 export const deepEquals = (a: unknown, b: unknown) => {
-  return a === b;
+  // === 가 아닌 Object.is() 사용
+  if (Object.is(a, b)) {
+    return true;
+  }
+  const isNull = a === null || b === null;
+  const isNotObject = typeof a !== "object" || typeof b !== "object";
+  // 둘 중에 하나라도 null 또는 object 타입이 아닐 경우
+  if (isNull || isNotObject) {
+    return false;
+  }
+  // 서로 다른 참조를 가진 객체 또는 배열
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  /* 배열 얕게 비교 */
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  /* 중첩된 구조 깊게 비교를 위한 a, b 를 인덱싱 가능한 타입으로 간주하도록 설정 */
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+
+  for (const key of aKeys) {
+    // 깊은 비교를 위하여 재귀 호출
+    if (!Object.hasOwn(b, key) || !deepEquals(objA[key], objB[key])) {
+      return false;
+    }
+  }
+  return true;
 };

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,3 +1,30 @@
 export const deepEquals = (a: unknown, b: unknown) => {
-  return a === b;
+  // === 가 아닌 Object.is() 사용
+  if (Object.is(a, b)) {
+    return true;
+  }
+  const isNull = a === null || b === null;
+  const isNotObject = typeof a !== "object" || typeof b !== "object";
+  // 둘 중에 하나라도 null 또는 object 타입이 아닐 경우
+  if (isNull || isNotObject) {
+    return false;
+  }
+  // 서로 다른 참조를 가진 객체 또는 배열
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  /* 배열 얕게 비교 */
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  /* 중첩된 구조 깊게 비교를 위한 a, b 를 인덱싱 가능한 타입으로 간주하도록 설정 */
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+
+  for (const key of aKeys) {
+    // b 가 key 를 가지고 있지 않거나, a와 b의 값이 다르다는 조건
+    if (!Object.hasOwn(b, key) || !deepEquals(objA[key], objB[key])) {
+      return false;
+    }
+  }
+  return true;
 };

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,3 +1,30 @@
 export const shallowEquals = (a: unknown, b: unknown) => {
-  return a === b;
+  // === 가 아닌 Object.is() 사용
+  if (Object.is(a, b)) {
+    return true;
+  }
+  const isNull = a === null || b === null;
+  const isNotObject = typeof a !== "object" || typeof b !== "object";
+  // 둘 중에 하나라도 null 또는 object 타입이 아닐 경우
+  if (isNull || isNotObject) {
+    return false;
+  }
+  // 서로 다른 참조를 가진 객체 또는 배열
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  /* 배열 얕게 비교 */
+  if (aKeys.length !== bKeys.length) {
+    return false;
+  }
+  /* 중첩된 구조 깊게 비교를 위한 a, b 를 인덱싱 가능한 타입으로 간주하도록 설정 */
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+
+  for (const key of aKeys) {
+    // b 가 key 를 가지고 있지 않거나, a와 b의 값이 다르다는 조건
+    if (!Object.hasOwn(b, key) || !Object.is(objA[key], objB[key])) {
+      return false;
+    }
+  }
+  return true;
 };

--- a/packages/lib/src/hocs/deepMemo.ts
+++ b/packages/lib/src/hocs/deepMemo.ts
@@ -1,5 +1,7 @@
 import type { FunctionComponent } from "react";
+import { memo } from "./memo";
+import { deepEquals } from "../equals";
 
 export function deepMemo<P extends object>(Component: FunctionComponent<P>) {
-  return Component;
+  return memo(Component, deepEquals);
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -4,7 +4,7 @@ import { useRef } from "../hooks";
 
 export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
   // 새로운 컴포넌트 정의, 렌더링 할 때 props 넘겨줌.
-  const memoizatedComponent: FunctionComponent<P> = (props) => {
+  const memoizedComponent: FunctionComponent<P> = (props) => {
     const cache = useRef<{ preProps: P; result: React.ReactElement } | null>(null);
     // 최초 렌더링 또는 props 변경 시 컴포넌트 호출하여 렌더링 값 설정
     if (cache.current === null || !equals(cache.current.preProps, props)) {
@@ -13,5 +13,5 @@ export function memo<P extends object>(Component: FunctionComponent<P>, equals =
     }
     return cache.current.result;
   };
-  return memoizatedComponent;
+  return memoizedComponent;
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -1,6 +1,17 @@
 import { type FunctionComponent } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "../hooks";
 
 export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
-  return Component;
+  // 새로운 컴포넌트 정의, 렌더링 할 때 props 넘겨줌.
+  const memoizatedComponent: FunctionComponent<P> = (props) => {
+    const cache = useRef<{ preProps: P; result: React.ReactElement } | null>(null);
+    // 최초 렌더링 또는 props 변경 시 컴포넌트 호출하여 렌더링 값 설정
+    if (cache.current === null || !equals(cache.current.preProps, props)) {
+      const newResult = Component(props);
+      cache.current = { preProps: props, result: newResult };
+    }
+    return cache.current.result;
+  };
+  return memoizatedComponent;
 }

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -3,5 +3,30 @@ import { useCallback } from "./useCallback";
 import { useRef } from "./useRef";
 
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
-  return fn;
+  // 매 렌더링마다 latestFnRef.current 값이 업데이트됩니다.
+  const latestFnRef = useRef(fn);
+  latestFnRef.current = fn;
+
+  // dispatcherRef: "latestFnRef을 여는 행위"를 하는 함수를 담을겁니다. 해당 함수는 자체는 변하지 않음.
+  const dispatcherRef = useRef<(...args: any[]) => any>();
+
+  // "latestFnRef을 여는 행위"를 정의합니다.
+  // 이 함수는 매 렌더링마다 새로 생성됩니다.
+  // 따라서 항상 최신 스코프의 `latestFnRef`를 참조합니다.
+  const dispatcher = (...args: any[]) => {
+    return latestFnRef.current(...args);
+  };
+
+  // 새로 생성된 dispatcher 함수를 dispatcherRef의 내용물로 업데이트.
+  dispatcherRef.current = dispatcher;
+
+  // autoCallback: 이 함수의 참조는 절대 변하면 안 됩니다.
+  // autoCallback은 오직 "dispatcherRef를 열어서 그 안의 dispatcher를 실행"하는 것입니다.
+  const autoCallback = useCallback((...args: any[]) => {
+    // 이 함수가 호출될 때, 그 시점의 dispatcherRef를 열고,
+    // 그 안에 있는 최신 dispatcher를 실행합니다.
+    return dispatcherRef.current?.(...args);
+  }, []); // 참조 고정
+
+  return autoCallback as T;
 };

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import type { DependencyList } from "react";
 import { useMemo } from "./useMemo";
 

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
 import type { DependencyList } from "react";
+import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
-  // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  const callbackFunc = useMemo(() => factory, _deps);
+  return callbackFunc as T;
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -4,12 +4,12 @@ import { useRef } from "./useRef";
 
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
   // 단 한 번만 초기화. 컴포넌트가 사라지기 전까지 유지.
-  const memoizatedRef = useRef<{ deps: DependencyList; result: T } | null>(null);
+  const memoizedRef = useRef<{ deps: DependencyList; result: T } | null>(null);
 
-  if (memoizatedRef.current === null || !_equals(memoizatedRef.current.deps, _deps)) {
+  if (memoizedRef.current === null || !_equals(memoizedRef.current.deps, _deps)) {
     // 만약 새로운 값으로 업데이트 해야한다면 랜더링을 유발하지 않는 방식으로..
-    memoizatedRef.current = { deps: _deps, result: factory() };
+    memoizedRef.current = { deps: _deps, result: factory() };
   }
   // 마지막엔 저장된 result 반환
-  return memoizatedRef.current.result;
+  return memoizedRef.current.result;
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -1,8 +1,16 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import type { DependencyList } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "./useRef";
 
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
   // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+  const memoizatedRef = useRef(null);
+  if (memoizatedRef.current === null || !_equals(memoizatedRef.current.deps, _deps)) {
+    memoizatedRef.current = { deps: _deps, result: factory() };
+    return memoizatedRef.current.result;
+  }
+
+  if (_equals(memoizatedRef.current.deps, _deps) && _deps) {
+    return memoizatedRef.current.result;
+  }
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -3,14 +3,13 @@ import { shallowEquals } from "../equals";
 import { useRef } from "./useRef";
 
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요.
-  const memoizatedRef = useRef(null);
-  if (memoizatedRef.current === null || !_equals(memoizatedRef.current.deps, _deps)) {
-    memoizatedRef.current = { deps: _deps, result: factory() };
-    return memoizatedRef.current.result;
-  }
+  // 단 한 번만 초기화. 컴포넌트가 사라지기 전까지 유지.
+  const memoizatedRef = useRef<{ deps: DependencyList; result: T } | null>(null);
 
-  if (_equals(memoizatedRef.current.deps, _deps) && _deps) {
-    return memoizatedRef.current.result;
+  if (memoizatedRef.current === null || !_equals(memoizatedRef.current.deps, _deps)) {
+    // 만약 새로운 값으로 업데이트 해야한다면 랜더링을 유발하지 않는 방식으로..
+    memoizatedRef.current = { deps: _deps, result: factory() };
   }
+  // 마지막엔 저장된 result 반환
+  return memoizatedRef.current.result;
 }

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,4 +1,6 @@
+import { useState } from "react";
+
 export function useRef<T>(initialValue: T): { current: T } {
-  // useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  const [ref] = useState(() => ({ current: initialValue }));
+  return ref;
 }

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -8,5 +8,11 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 export const useRouter = <T extends RouterInstance<AnyFunction>, S>(router: T, selector = defaultSelector<T, S>) => {
   // useSyncExternalStore를 사용하여 router의 상태를 구독하고 가져오는 훅을 구현합니다.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(router);
+  const subscribe = (callback: () => void) => {
+    return router.subscribe(callback);
+  };
+  const getSnapShot = () => {
+    return shallowSelector(router);
+  };
+  return useSyncExternalStore(subscribe, getSnapShot);
 };

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -1,9 +1,28 @@
 import { useRef } from "react";
 import { shallowEquals } from "../equals";
+import { useCallback } from "./useCallback";
 
 type Selector<T, S = T> = (state: T) => S;
 
 export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
   // 이전 상태를 저장하고, shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
-  return (state: T): S => selector(state);
+  // selector 저장용 ref
+  const selectorRef = useRef(selector);
+  // 렌더링 시 항상 최신 selector 적용
+  selectorRef.current = selector;
+  // 이전 결과물 저장용 ref
+  const valueRef = useRef(null);
+  // 의존성 배열이 비어 있는 useCallback (한 번만 생성)
+  const memoizedSelector = useCallback((state) => {
+    // 최신 값 도출
+    const newVal = selectorRef.current(state);
+    // 최신과 이전 비교하여 같으면 이전 값 return
+    if (shallowEquals(valueRef.current, newVal)) {
+      return valueRef.current;
+    }
+    // 최신 값 설정
+    valueRef.current = newVal;
+    return valueRef.current;
+  }, []);
+  return memoizedSelector;
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,7 +1,21 @@
 import { useState } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "./useRef";
 
 export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
-  // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
-  return useState(initialValue);
+  // 1. useState 를 사용하여 실제 상태 관리.
+  const [currentState, originSetState] = useState(initialValue);
+  // 2. 반환할 originSetState 함수 정의.
+  const customSetState = (newVal: unknown) => {
+    // 새롭게 전달 받은 값을 계산. 함수인 경우를 고려하여 새로운 값을 도출
+    const actualNewVal = typeof newVal === "function" ? newVal(currentState) : newVal;
+    // 얕은 비교 사용하여 새로운 값과 현재 값을 비교 (상태 변경을 감지)
+    if (!shallowEquals(actualNewVal, currentState)) {
+      // 비교 값이 다르다면, origin 을 호출하여 상태 값 업데이트
+      originSetState(actualNewVal);
+    }
+  };
+  // 3. 매 랜더링 시 최신 함수를 할당.
+  const customSetStateRef = useRef(customSetState);
+  return [currentState, customSetStateRef.current];
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,21 +1,34 @@
 import { useState } from "react";
 import { shallowEquals } from "../equals";
-import { useRef } from "./useRef";
+import { useCallback } from "./useCallback";
 
-export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
-  // 1. useState 를 사용하여 실제 상태 관리.
-  const [currentState, originSetState] = useState(initialValue);
-  // 2. 반환할 originSetState 함수 정의.
-  const customSetState = (newVal: unknown) => {
-    // 새롭게 전달 받은 값을 계산. 함수인 경우를 고려하여 새로운 값을 도출
-    const actualNewVal = typeof newVal === "function" ? newVal(currentState) : newVal;
-    // 얕은 비교 사용하여 새로운 값과 현재 값을 비교 (상태 변경을 감지)
-    if (!shallowEquals(actualNewVal, currentState)) {
-      // 비교 값이 다르다면, origin 을 호출하여 상태 값 업데이트
-      originSetState(actualNewVal);
-    }
-  };
-  // 3. 매 랜더링 시 최신 함수를 할당.
-  const customSetStateRef = useRef(customSetState);
-  return [currentState, customSetStateRef.current];
+export const useShallowState = <T>(initialValue: T | (() => T)): [T, (newState: T | ((prevState: T) => T)) => void] => {
+  // 1. useState를 사용하여 실제 상태 값과 원본 setState 함수를 관리.
+  const [state, originalSetState] = useState(initialValue);
+
+  // 2. useShallowState가 외부에 반환할 setState 함수를 useCallback으로 감싸서 참조를 고정.
+  //    이 함수는 originalSetState의 함수형 업데이트를 사용하여 항상 최신 prevState를 받습니다.
+  //    따라서 이 함수 자체는 외부 스코프의 'state' 변수에 의존할 필요가 없습니다.
+  const customSetState = useCallback((newState: T | ((prevState: T) => T)) => {
+    originalSetState((prevState) => {
+      // <-- 변경점 1: originalSetState를 함수형으로 호출
+      // newState가 함수 형태일 경우, 최신 prevState를 사용하여 실제 새 값을 계산합니다.
+      const actualNewValue =
+        typeof newState === "function"
+          ? (newState as (prevState: T) => T)(prevState) // <-- 변경점 2: prevState 사용
+          : newState;
+
+      // 최신 prevState와 계산된 actualNewValue를 shallowEquals로 비교합니다.
+      if (!shallowEquals(actualNewValue, prevState)) {
+        // <-- 변경점 3: prevState 사용
+        // 두 값이 다르면, actualNewValue로 상태를 업데이트합니다.
+        return actualNewValue;
+      }
+      // 두 값이 같으면, 이전 상태를 그대로 반환하여 상태 업데이트를 건너뛰고 리렌더링을 방지합니다.
+      return prevState;
+    });
+  }, []); // <-- 변경점 4: 의존성 배열을 비움
+
+  // 현재 상태 값과 안정적인 setState 함수를 반환합니다.
+  return [state, customSetState]; // <-- 변경점 5: customSetStateRef.current 대신 customSetState 반환
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,21 +1,34 @@
 import { useState } from "react";
 import { shallowEquals } from "../equals";
-import { useRef } from "./useRef";
+import { useCallback } from "./useCallback";
 
-export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
-  // 1. useState 를 사용하여 실제 상태 관리.
-  const [currentState, originSetState] = useState(initialValue);
-  // 2. 반환할 originSetState 함수 정의.
-  const customSetState = (newVal: unknown) => {
-    // 새롭게 전달 받은 값을 계산. 함수인 경우를 고려하여 새로운 값을 도출
-    const actualNewVal = typeof newVal === "function" ? newVal(currentState) : newVal;
-    // 얕은 비교 사용하여 새로운 값과 현재 값을 비교 (상태 변경을 감지)
-    if (!shallowEquals(actualNewVal, currentState)) {
-      // 비교 값이 다르다면, origin 을 호출하여 상태 값 업데이트
-      originSetState(actualNewVal);
-    }
-  };
-  // 3. 매 랜더링 시 최신 함수를 할당.
-  const customSetStateRef = useRef(customSetState);
-  return [currentState, customSetStateRef.current];
+export const useShallowState = <T>(initialValue: T | (() => T)): [T, (newState: T | ((prevState: T) => T)) => void] => {
+  // 1. useState를 사용하여 실제 상태 값과 원본 setState 함수를 관리.
+  const [state, originalSetState] = useState(initialValue);
+
+  // 2. useShallowState가 외부에 반환할 setState 함수를 useCallback으로 감싸서 참조를 고정.
+  //    이 함수는 originalSetState의 함수형 업데이트를 사용하여 항상 최신 prevState를 받습니다.
+  //    따라서 이 함수 자체는 외부 스코프의 'state' 변수에 의존할 필요가 없습니다.
+  const customSetState = useCallback((newState: T | ((prevState: T) => T)) => {
+    // 변경점 1: originalSetState를 함수형으로 호출
+    originalSetState((prevState) => {
+      // newState가 함수 형태일 경우, 최신 prevState를 사용하여 실제 새 값을 계산합니다.
+      const actualNewValue =
+        typeof newState === "function"
+          ? (newState as (prevState: T) => T)(prevState) // <-- 변경점 2: prevState 사용
+          : newState;
+
+      // 최신 prevState와 계산된 actualNewValue를 shallowEquals로 비교.
+      // 변경점 3: prevState 사용
+      if (!shallowEquals(actualNewValue, prevState)) {
+        // 두 값이 다르면, actualNewValue로 상태를 업데이트합니다.
+        return actualNewValue;
+      }
+      // 두 값이 같으면, 이전 상태를 그대로 반환하여 상태 업데이트를 건너뛰고 리렌더링을 방지합니다.
+      return prevState;
+    });
+  }, []); // 변경점 4: 의존성 배열을 비움
+
+  // 현재 상태 값과 안정적인 setState 함수를 반환.
+  return [state, customSetState]; // <-- 변경점 5: customSetStateRef.current 대신 customSetState 반환
 };

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -5,5 +5,15 @@ type Storage<T> = ReturnType<typeof createStorage<T>>;
 
 export const useStorage = <T>(storage: Storage<T>) => {
   // useSyncExternalStore를 사용해서 storage의 상태를 구독하고 가져오는 훅을 구현해보세요.
-  return storage.get();
+  const subscribe = (callback: () => void) => {
+    return storage.subscribe(callback);
+  };
+
+  const getSnapShot = () => {
+    return storage.get();
+  };
+
+  const value = useSyncExternalStore(subscribe, getSnapShot, null);
+
+  return value;
 };

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -12,8 +12,5 @@ export const useStorage = <T>(storage: Storage<T>) => {
   const getSnapShot = () => {
     return storage.get();
   };
-
-  const value = useSyncExternalStore(subscribe, getSnapShot, null);
-
-  return value;
+  return useSyncExternalStore(subscribe, getSnapShot, null);
 };

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -12,5 +12,5 @@ export const useStorage = <T>(storage: Storage<T>) => {
   const getSnapShot = () => {
     return storage.get();
   };
-  return useSyncExternalStore(subscribe, getSnapShot, null);
+  return useSyncExternalStore(subscribe, getSnapShot);
 };

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -8,6 +8,13 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 
 export const useStore = <T, S = T>(store: Store<T>, selector: (state: T) => S = defaultSelector<T, S>) => {
   // useSyncExternalStore와 useShallowSelector를 사용해서 store의 상태를 구독하고 가져오는 훅을 구현해보세요.
-  const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(store.getState());
+  const memoizedSelector = useShallowSelector(selector);
+  const subscribe = (callback: () => void) => {
+    return store.subscribe(callback);
+  };
+  const getSnapShot = () => {
+    // "결과값이 이전과 같다면, 새로운 객체를 만들지 말고 이전에 만들었던 객체를 그대로 반환"
+    return memoizedSelector(store.getState());
+  };
+  return useSyncExternalStore(subscribe, getSnapShot);
 };


### PR DESCRIPTION
## 과제 체크포인트

### 배포 링크

[PR만이 유일하게 이 잔혹한 세계에 저항할 방법이다!!](https://heojungseok.github.io/front_6th_chapter1-3/)

<!--
배포 링크를 적어주세요
예시: https://<username>.github.io/front-6th-chapter1-3/

배포가 완료되지 않으면 과제를 통과할 수 없습니다.
배포 후에 정상 작동하는지 확인해주세요.
-->

### 기본과제

#### equalities

- [x] shallowEquals 구현 완료
- [x] deepEquals 구현 완료

#### hooks

- [x] useRef 구현 완료
- [x] useMemo 구현 완료
- [x] useCallback 구현 완료
- [x] useDeepMemo 구현 완료
- [x] useShallowState 구현 완료
- [x] useAutoCallback 구현 완료

#### High Order Components

- [x] memo 구현 완료
- [x] deepMemo 구현 완료

### 심화 과제

#### hooks

- [x] createObserver를 useSyncExternalStore에 사용하기 적합한 코드로 개선
- [x] useShallowSelector 구현
- [x] useStore 구현
- [x] useRouter 구현
- [x] useStorage 구현

### context

- [x] ToastContext, ModalContext 개선

## 과제 셀프회고

<!-- 과제에 대한 회고를 작성해주세요 -->

React, Beyond the Basics....
기초를 넘어서기 위한 3주차 과제가 끝났다. 1, 2주차에서 JS 로 SPA 를 구현하면서 3주차가 되게 힘들거라고 예상했다.
리액트를 써보지 않은 입장에서 React hooks, React 메모이제이션, ... 험난했다. (+ Typescript 또한 안써봤다...)
그래도 1, 2 주차에 예방주사를 좀 맞아 놓은 덕에 내 예상보다는 조금은 수월하게 진행했다. 그렇다고 절대 쉽다는 말은 아니다.
1주였지만 리액트라는 것을 조금은 알아간거에 만족하고있다. 더 알아갈 일만 남았다.
그리고 양질의 과제 준비하시느라 고생 많으셨습니다. 준일 코치님! 
"To infinity… and beyond!"
<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/03fb19ff-4611-47d3-9d67-65c5d760c7d7" />

#### TIL 링크
* [equalities 만들기](https://velog.io/@jungseokheo/til5th)
* [React Hooks: useRef](https://velog.io/@jungseokheo/til6th)
* [React Hooks: useMemo](https://velog.io/@jungseokheo/til7th)
* [React Hooks: useCallback](https://velog.io/@jungseokheo/til8th)
* [React Hooks: useShallowState](https://velog.io/@jungseokheo/til9th)
* [React Hooks: useAutoCallback](https://velog.io/@jungseokheo/til10th)
* [Higher-Order Component - HOC: memo](https://velog.io/@jungseokheo/til11th)
* [활용해보기](https://velog.io/@jungseokheo/til12th)

### 기술적 성장

<!-- 예시
- 새로 학습한 개념
- 기존 지식의 재발견/심화
- 구현 과정에서의 기술적 도전과 해결
-->
새로 학습한 개념들은 너무나도 많았다. 어쩌면 전부 다 새로 학습한 개념이라해도 무방하다.
나는 최대한 덜 움직이고 효율적이게 효과를 내는 것을 좋아하기에 **메모이제이션** 이 제일 기억에 남는다.

`memo (컴포넌트 메모이제이션), useMemo (값을 메모이제이션), useCallback (함수를 메모이제이션)`

* 불필요한 렌더링을 방지
* 복잡한 계산과 큰 데이터 세트를 다룰 때 이전 결과를 재사용함으로써 비용을 줄일 수 있음
 ⬇️ ⬇️ ⬇️ ⬇️ ⬇️
* 컴포넌트 예측 가능성을 높임
* 버그를 줄임
* 확장성과 유지보수성 증대

메모이제이션에 대한 생각은 아래 항목에 정리하겠다.

### 자랑하고 싶은 코드

<!-- 예시
- 특히 만족스러운 구현
- 리팩토링이 필요한 부분
- 코드 설계 관련 고민과 결정
-->
커밋 링크: [refactor: ToastProvider 리팩토링](https://github.com/hanghae-plus/front_6th_chapter1-3/pull/19/commits/09ec2333645d891a882766a32d2bd6d63c38b5f3)

```javascript
/* eslint-disable react-refresh/only-export-components */
import { createContext, memo, type PropsWithChildren, useContext, useReducer } from "react";
import { createPortal } from "react-dom";
import { Toast } from "./Toast";
import { createActions, initialState, toastReducer, type ToastType } from "./toastReducer";
import { debounce } from "../../utils";
import { useCallback, useMemo } from "@hanghae-plus/lib/src/hooks";

type ShowToast = (message: string, type: ToastType) => void;
type Hide = () => void;
// Context 분리
// 상태 Context
const ToastStateContext = createContext<{
  message: string;
  type: ToastType;
}>({ ...initialState });
// 이벤트 Context
const ToastCommandContext = createContext<{ show: ShowToast; hide: Hide }>({
  show: () => null,
  hide: () => null,
});

const DEFAULT_DELAY = 3000;
// Hook 수정
export const useToastCommand = () => useContext(ToastCommandContext);
export const useToastState = () => useContext(ToastStateContext);

export const ToastProvider = memo(({ children }: PropsWithChildren) => {
  const [state, dispatch] = useReducer(toastReducer, initialState);
  const { show, hide } = useMemo(() => createActions(dispatch), [dispatch]);
  const visible = state.message !== "";
  // 메모이제이션
  const hideAfter = useMemo(() => debounce(hide, DEFAULT_DELAY), [hide]);
  // 메모이제이션
  const showWithHide: ShowToast = useCallback(
    (...args) => {
      show(...args);
      hideAfter();
    },
    [show, hideAfter],
  );
  // props 로 넘길 값 (메모이제이션)
  const commandValue = useMemo(
    () => ({
      show: showWithHide,
      hide: hide,
    }),
    [showWithHide, hide],
  );
  return (
    // Provider 중첩
    <ToastCommandContext.Provider value={commandValue}>
      <ToastStateContext.Provider value={state}>
        {children}
        {visible && createPortal(<Toast />, document.body)}
      </ToastStateContext.Provider>
    </ToastCommandContext.Provider>
  );
});


```

<img width="1567" height="626" alt="구현_힌트" src="https://github.com/user-attachments/assets/828ec475-09f9-4db3-9822-1bacde7630a5" />

위 이미지는 Gemini CLI 를 통해서 리팩토링을 위해서는 어떻게 해야하는지에 대한 구현 힌트를 얻은 부분이다. (+ 3팀분들의 도움)
처음부터 끝 까지 스스로 하진 못했지만 내가 생각하기엔 배운 내용을 정리 및 활용하기에 좋았다.
좋은 테스트 항목을 넣어주신거 같다. 약간 엑기스 같은 느낌이 강하다.


### 개선이 필요하다고 생각하는 코드

<!-- 예시
- 특히 만족스러운 구현
- 리팩토링이 필요한 부분
- 코드 설계 관련 고민과 결정
-->

```ts
import type { AnyFunction } from "../types";
import { useCallback } from "./useCallback";
import { useRef } from "./useRef";

export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
  // 매 렌더링마다 latestFnRef.current 값이 업데이트됩니다.
  const latestFnRef = useRef(fn);
  latestFnRef.current = fn;

  // dispatcherRef: "latestFnRef을 여는 행위"를 하는 함수를 담을겁니다. 해당 함수는 자체는 변하지 않음.
  const dispatcherRef = useRef<(...args: any[]) => any>();

  // "latestFnRef을 여는 행위"를 정의합니다.
  // 이 함수는 매 렌더링마다 새로 생성됩니다.
  // 따라서 항상 최신 스코프의 `latestFnRef`를 참조합니다.
  const dispatcher = (...args: any[]) => {
    return latestFnRef.current(...args);
  };

  // 새로 생성된 dispatcher 함수를 dispatcherRef의 내용물로 업데이트.
  dispatcherRef.current = dispatcher;

  // autoCallback: 이 함수의 참조는 절대 변하면 안 됩니다.
  // autoCallback은 오직 "dispatcherRef를 열어서 그 안의 dispatcher를 실행"하는 것입니다.
  const autoCallback = useCallback((...args: any[]) => {
    // 이 함수가 호출될 때, 그 시점의 dispatcherRef를 열고,
    // 그 안에 있는 최신 dispatcher를 실행합니다.
    return dispatcherRef.current?.(...args);
  }, []); // 참조 고정

  return autoCallback as T;
};

```
두 개의 ref 를 사용하여 코드의 복잡성을 증가 시킴.

### 학습 효과 분석

<!-- 예시
- 가장 큰 배움이 있었던 부분
- 추가 학습이 필요한 영역
- 실무 적용 가능성
-->

가장 큰 배움은 전반적인 리액트의 훅을 알게된 점이다.
과제지만 조금은 리액트를 뜯어본 느낌이였고 리액트가 어떤 방식으로 실행하는지 알아가는 과정 덕에
다음 과제 또는 다른 프로젝트에서 리액트를 써본다면 이번보다는 더 친해지지 않을까 싶다.

추가적으로는 Typescript 도 학습을 해야한다고 느꼈다. 어떻게 쓰겠다고 명시한다는게 좋지만 
과제를 하면서 살짝 귀찮다고 느껴지는 경우도 많았다. 아직 손에 익지 않아서라고 생각이 든다.
익숙해지면 정말 개발에 많이 유용할 것 같다. 


### 과제 피드백

<!-- 예시
- 과제에서 모호하거나 애매했던 부분
- 과제에서 좋았던 부분
-->

e2e 테스트에서 맨 마지막 항목이 제일 인상 깊습니다. 아무래도 과제의 마침표를 찍는 테스트이기도 하지만 
위에서도 얘기했듯이 3 주차 과제의 주제를 명확히 담고 있다고 개인적으로 생각합니다. **(내가 만들고 내가 활용한다.)**
하지만 심화 까지 가야지만 **누릴 수 있는 테스트**이기에 기본에서도 비슷한 포맷의 테스트가 있다면 좋을 것 같습니다. 
(기본에도 해당 뉘앙스의 테스트가 있는데 제가 못 알아챘을 수 있습니다. 그렇다면 죄송합니다.)

## 학습 갈무리

### 리액트의 렌더링이 어떻게 이루어지는지 정리해주세요.

<!-- 예시
- 리액트의 렌더링 과정
- 리액트의 렌더링 최적화 방법
- 리액트의 렌더링과 관련된 개념들 (예: Virtual DOM, Reconciliation 등)
- 리액트의 렌더링과 관련된 라이프사이클 메서드
- 리액트의 렌더링과 관련된 Hooks (예: useMemo, useCallback 등)
-->

#### 렌더링이 발생 되는 상황
1. 최초 렌더링: 애플리케이션이 처음 로드 될 때
2. 상태 변경: 컴포넌트 내에서 `useState` 나 `useReducer` 의 setter 함수가 호출되어 상태가 변경 될 때
3. 부모 컴포넌트의 리렌더링: **특별한 최적화 처리**를 하지 않았다면 모든 자식 컴포넌트 리렌더링

#### 렌더 와 커밋
1. 렌더: 계획 세우기 (DOM 변경 없음)
- 리렌더링 트리거: state 변경등으로 리렌더링 시작
- Virtual DOM 생성
2. 커밋: DOM 에 변경 사항 적용
- 재조정(Reconciliation): 새로 만들어진 Virtual DOM과 이전 렌더링 때 만들었던 Virtual DOM을 비교 (Diffing)
- 최소한의 변경 사항 계산: Diffing 알고리즘을 통해서 계산
- DOM 업데이트

#### 📍정리
1. State나 Props가 변경되면 컴포넌트의 리렌더링이 시작됩니다.
4. React는 컴포넌트를 실행하여 Virtual DOM이라는 가상의 UI 구조를 만듭니다.
5. 이전의 Virtual DOM과 비교하여 바뀐 부분만 찾아냅니다 (Reconciliation).
6. 바뀐 부분만 실제 DOM에 적용하여 성능을 최적화합니다.


### 메모이제이션에 대한 나의 생각을 적어주세요.

<!-- 예시
- 메모이제이션이 언제 필요할까?
- 메모이제이션을 사용하지 않으면 어떤 문제가 발생할까?
- 메모이제이션을 사용했을 때의 장점과 단점은 무엇일까?
- 메모이제이션을 사용하지 않고도 해결할 수 있는 방법은 무엇일까?
-->

성격, 성향적으로 효율성을 추구하는 나에게는 되게 신선하게 다가온 개념이었다.
먼저, 리액트가 해당 개념을 첫 도입한게 18년 10월이라고 한다. 그 뒤로 Hooks가 공식 도입되면서
코드 구조가 깔끔해지고 입문 장벽이 낮아졌다고 한다.
물론 남발하면 좋지 않지만 

1. 불필요한 캐싱 비용
4. 의존성 관리 어려움
5. 코드 가독성 저하

적재적소에 사용하면 성능 최적화는 보장이 되니까 굉장히 매력적이다.
특정 상황에 따라 사용하는 Hooks 가 달라지는 것도 좋다. 개발자에게 맥가이버 칼을 쥐어준 느낌이랄까...
과제로 인해 처음 접해본 개념이니까 아직은 사용 빈도가 높진 않지만 나중엔 꽤나 밥 먹듯이 사용할 수 있을 것 같은 예감이 든다.

<details>
   <summary>내가 구현한 hooks </summary>
   <div markdown="1">

```javascript

// useMemo.ts
import type { DependencyList } from "react";
import { shallowEquals } from "../equals";
import { useRef } from "./useRef";

export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
  // 단 한 번만 초기화. 컴포넌트가 사라지기 전까지 유지.
  const memoizedRef = useRef<{ deps: DependencyList; result: T } | null>(null);

  if (memoizedRef.current === null || !_equals(memoizedRef.current.deps, _deps)) {
    // 만약 새로운 값으로 업데이트 해야한다면 랜더링을 유발하지 않는 방식으로..
    memoizedRef.current = { deps: _deps, result: factory() };
  }
  // 마지막엔 저장된 result 반환
  return memoizedRef.current.result;
}

// useCallback.ts
import type { DependencyList } from "react";
import { useMemo } from "./useMemo";

export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
  const callbackFunc = useMemo(() => factory, _deps);
  return callbackFunc as T;
}

// memo.ts
import { type FunctionComponent } from "react";
import { shallowEquals } from "../equals";
import { useRef } from "../hooks";

export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
  // 새로운 컴포넌트 정의, 렌더링 할 때 props 넘겨줌.
  const memoizedComponent: FunctionComponent<P> = (props) => {
    const cache = useRef<{ preProps: P; result: React.ReactElement } | null>(null);
    // 최초 렌더링 또는 props 변경 시 컴포넌트 호출하여 렌더링 값 설정
    if (cache.current === null || !equals(cache.current.preProps, props)) {
      const newResult = Component(props);
      cache.current = { preProps: props, result: newResult };
    }
    return cache.current.result;
  };
  return memoizedComponent;
}


```
    </div>
</details>


### 컨텍스트와 상태관리에 대한 나의 생각을 적어주세요.

<!-- 예시
- 컨텍스트와 상태관리가 필요한 이유는 무엇일까?
- 컨텍스트와 상태관리를 사용하지 않으면 어떤 문제가 발생할까?
- 컨텍스트와 상태관리를 사용했을 때의 장점과 단점은 무엇일까?
- 컨텍스트와 상태관리를 사용하지 않고도 해결할 수 있는 방법은 무엇일까?
- 컨텍스트와 상태관리를 사용할 때 주의해야 할 점은 무엇일까?
-->




## 리뷰 받고 싶은 내용

<!--
피드백 받고 싶은 내용을 구체적으로 남겨주세요
모호한 요청은 피드백을 남기기 어렵습니다.

참고링크: https://chatgpt.com/share/675b6129-515c-8001-ba72-39d0fa4c7b62

모호한 질문의 예시)
- 무엇을 질문해야 할지 몰라서 코치님이 보시기에 고쳐야할것들 전반적으로 피드백 부탁드립니다.
- 코드 스타일에 대한 피드백 부탁드립니다.
- 코드 구조에 대한 피드백 부탁드립니다.
- 개념적인 오류에 대한 피드백 부탁드립니다.
- 추가 구현이 필요한 부분에 대한 피드백 부탁드립니다.

구체적인 질문의 예시)
- 파일A의 함수B와 그 안의 변수명을 보면 직관성이 떨어지는 것 같습니다. 함수와 변수 이름을 더 명확하게 지을 방법에 대해 조언해 주실 수 있나요?
- 현재 파일 단위로 코드를 분리했지만, 이번 주차 발제를 기준으로 봤을 때 모듈화나 계층화에서 부족함이 있는 것 같습니다. 특히 A와 B 부분에서 모듈화를 더 진행할지 그대로 둘지 고민하였습니다. (...구체적인 고민 사항 적기...). 코치님의 의견이 궁금합니다.
- 옵저버 패턴을 사용해 상태 관리 로직을 구현해 보려 했습니다. 제가 구현한 코드가 옵저버 패턴에 맞게 잘 구성되었는지 검토해 주시고, 보완할 부분을 제안해 주실 수 있을까요?
- 컴포넌트 A를 테스트 할 때 B와의 의존성 때문에 테스트 코드를 작성하려다 포기했습니다. A와 B의 의존성을 낮추고 테스트 가능성을 높이는 구조 개선 방안이 있을까요?

과제에서 디테일한 피드백을 받기 위해선 여러분의 생각을 디테일하게 표현해주셔야 한답니다.

가령, "전반적으로 이 라우터 구조가 규모가 커졌을 때 유지보수나 기능 확장에 유리한지, 아니면 리팩토링이 필요할지 조언을 받고 싶습니다" 라는 질문이 있을 때, 답변드리기가 어려워요. 
이럴 때는 "기능 확장" 상황을 먼저 가정해봐야합니다. 테스트의 엣지케이스를 작성하는 것 처럼요! 그리고 그 상황에 대해 내가 작성한 코드가 이러저러한 이유 때문에 대응가능할 것 같은데 혹시 더 고려해야할 부분이 있을지를 물어보는거죠.

이건 코치에게 이야기할 때 뿐만 아니라 팀원에게 이야기할 때에도 동일해요. 여러분의 컨텍스트를 명확하게 전달하지 않으면 여러분과 이야기할 때 시간이 무척 오래 걸린답니다.

특히 멘토링 처럼 동기적으로 이루어지는 커뮤니케이션에서는 위와 같은 질문을 던져도, 상호 피드백으로 질문을 함께 만들어갈 수 있지만, 과제 피드백 처럼 비동기 방식 + 1회용 질문일 때에는 좋은 답변을 드리기가 어려운점 인지 부탁드립니다 ㅠㅠ
-->

1. 개선이 필요한 코드에서도 `useAutoCallback` 를 언급했습니다. latestFnRef와 dispatcherRef라는 두 개의 ref를 사용하여 구현했습니다. 주석으로 표기를 해놨으나 패턴을 쉽게 이해하기는 어려울 것으로 보입니다. 구조를 명확하지만 쉽게 파악할 수 있는 방법에 대해 리뷰 부탁드리겠습니다. 감사합니다.

<details>
<summary>useAutoCallback</summary>
<div markdown="1">

```ts
import type { AnyFunction } from "../types";
import { useCallback } from "./useCallback";
import { useRef } from "./useRef";

export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
  // 매 렌더링마다 latestFnRef.current 값이 업데이트됩니다.
  const latestFnRef = useRef(fn);
  latestFnRef.current = fn;

  // dispatcherRef: "latestFnRef을 여는 행위"를 하는 함수를 담을겁니다. 해당 함수는 자체는 변하지 않음.
  const dispatcherRef = useRef<(...args: any[]) => any>();

  // "latestFnRef을 여는 행위"를 정의합니다.
  // 이 함수는 매 렌더링마다 새로 생성됩니다.
  // 따라서 항상 최신 스코프의 `latestFnRef`를 참조합니다.
  const dispatcher = (...args: any[]) => {
    return latestFnRef.current(...args);
  };

  // 새로 생성된 dispatcher 함수를 dispatcherRef의 내용물로 업데이트.
  dispatcherRef.current = dispatcher;

  // autoCallback: 이 함수의 참조는 절대 변하면 안 됩니다.
  // autoCallback은 오직 "dispatcherRef를 열어서 그 안의 dispatcher를 실행"하는 것입니다.
  const autoCallback = useCallback((...args: any[]) => {
    // 이 함수가 호출될 때, 그 시점의 dispatcherRef를 열고,
    // 그 안에 있는 최신 dispatcher를 실행합니다.
    return dispatcherRef.current?.(...args);
  }, []); // 참조 고정

  return autoCallback as T;
};

```
</div>
</details>



