### PR TITLE
[4팀 오하늘] Chapter 1-3. React, Beyond the Basics

### DIFF
--- a/packages/app/404.html
+++ b/packages/app/404.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>상품 쇼핑몰</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/src/styles.css">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: "#3b82f6",
+            secondary: "#6b7280"
+          }
+        }
+      }
+    };
+  </script>
+</head>
+<body class="bg-gray-50">
+<div id="root"></div>
+<script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/packages/app/src/components/toast/ToastProvider.tsx
+++ b/packages/app/src/components/toast/ToastProvider.tsx
@@ -4,49 +4,72 @@ import { createPortal } from "react-dom";
 import { Toast } from "./Toast";
 import { createActions, initialState, toastReducer, type ToastType } from "./toastReducer";
 import { debounce } from "../../utils";
+import { useAutoCallback } from "@hanghae-plus/lib";
+import { useMemo, useRef } from "@hanghae-plus/lib/src/hooks";
 
 type ShowToast = (message: string, type: ToastType) => void;
 type Hide = () => void;
 
-const ToastContext = createContext<{
-  message: string;
-  type: ToastType;
+const ToastStateContext = createContext<{ message: string; type: ToastType }>({
+  message: "",
+  type: "info",
+});
+
+const ToastActionsContext = createContext<{
   show: ShowToast;
   hide: Hide;
 }>({
-  ...initialState,
   show: () => null,
   hide: () => null,
 });
 
+// const ToastContext = createContext<{
+//   message: string;
+//   type: ToastType;
+//   show: ShowToast;
+//   hide: Hide;
+// }>({
+//   ...initialState,
+//   show: () => null,
+//   hide: () => null,
+// });
+
 const DEFAULT_DELAY = 3000;
 
-const useToastContext = () => useContext(ToastContext);
-export const useToastCommand = () => {
-  const { show, hide } = useToastContext();
-  return { show, hide };
-};
-export const useToastState = () => {
-  const { message, type } = useToastContext();
-  return { message, type };
-};
+// const useToastContext = () => useContext(ToastContext);
+export const useToastState = () => useContext(ToastStateContext);
+export const useToastCommand = () => useContext(ToastActionsContext);
+// export const useToastCommand = () => {
+//   const { show, hide } = useToastContext();
+//   return { show, hide };
+// };
+// export const useToastState = () => {
+//   const { message, type } = useToastContext();
+//   return { message, type };
+// };
 
 export const ToastProvider = memo(({ children }: PropsWithChildren) => {
   const [state, dispatch] = useReducer(toastReducer, initialState);
-  const { show, hide } = createActions(dispatch);
+  // const { show, hide } = createActions(dispatch);
+  const { show, hide } = useRef(createActions(dispatch)).current;
   const visible = state.message !== "";
 
-  const hideAfter = debounce(hide, DEFAULT_DELAY);
+  const hideAfter = useMemo(() => debounce(hide, DEFAULT_DELAY), [hide]);
 
-  const showWithHide: ShowToast = (...args) => {
+  const showWithHide: ShowToast = useAutoCallback((...args) => {
     show(...args);
     hideAfter();
-  };
+  });
+
+  const actionsValue = useMemo(() => ({ show: showWithHide, hide }), [showWithHide, hide]);
+  const stateValue = useMemo(() => ({ message: state.message, type: state.type }), [state.message, state.type]);
 
   return (
-    <ToastContext value={{ show: showWithHide, hide, ...state }}>
-      {children}
-      {visible && createPortal(<Toast />, document.body)}
-    </ToastContext>
+    <ToastActionsContext.Provider value={actionsValue}>
+      <ToastStateContext.Provider value={stateValue}>
+        {children}
+        {visible && createPortal(<Toast />, document.body)}
+      </ToastStateContext.Provider>
+    </ToastActionsContext.Provider>
   );
 });

--- a/packages/app/src/components/toast/ToastProvider.tsx
+++ b/packages/app/src/components/toast/ToastProvider.tsx
@@ -23,34 +23,13 @@ const ToastActionsContext = createContext<{
   hide: () => null,
 });
 
-// const ToastContext = createContext<{
-//   message: string;
-//   type: ToastType;
-//   show: ShowToast;
-//   hide: Hide;
-// }>({
-//   ...initialState,
-//   show: () => null,
-//   hide: () => null,
-// });
-
 const DEFAULT_DELAY = 3000;
 
-// const useToastContext = () => useContext(ToastContext);
 export const useToastState = () => useContext(ToastStateContext);
 export const useToastCommand = () => useContext(ToastActionsContext);
-// export const useToastCommand = () => {
-//   const { show, hide } = useToastContext();
-//   return { show, hide };
-// };
-// export const useToastState = () => {
-//   const { message, type } = useToastContext();
-//   return { message, type };
-// };
 
 export const ToastProvider = memo(({ children }: PropsWithChildren) => {
   const [state, dispatch] = useReducer(toastReducer, initialState);
-  // const { show, hide } = createActions(dispatch);
   const { show, hide } = useRef(createActions(dispatch)).current;
   const visible = state.message !== "";
 

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -1,9 +1,19 @@
 type Listener = () => void;
 
+/**
+ * createObserver - 상태 변경을 감지하고 알림을 전달하는 Observer 패턴을 구현합니다.
+ *
+ * 특징:
+ * - useSyncExternalStore와 호환되는 subscribe 함수 제공
+ * - 여러 listener를 등록하고 일괄 알림 가능
+ * - 자동으로 cleanup 함수를 반환하여 메모리 누수 방지
+ *
+ * @returns {subscribe, notify} - subscribe: listener 등록, notify: 모든 listener에게 알림
+ */
+
 export const createObserver = () => {
   const listeners = new Set<Listener>();
 
-  // useSyncExternalStore 에서 활용할 수 있도록 subscribe 함수를 수정합니다.
   const subscribe = (fn: Listener) => {
     listeners.add(fn);
 

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -6,10 +6,10 @@ export const createObserver = () => {
   // useSyncExternalStore 에서 활용할 수 있도록 subscribe 함수를 수정합니다.
   const subscribe = (fn: Listener) => {
     listeners.add(fn);
-  };
 
-  const unsubscribe = (fn: Listener) => {
-    listeners.delete(fn);
+    return () => {
+      listeners.delete(fn);
+    };
   };
 
   const notify = () => listeners.forEach((listener) => listener());

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,3 +1,55 @@
+// 두 값의 깊은 비교를 수행합니다
+
 export const deepEquals = (a: unknown, b: unknown) => {
-  return a === b;
+  // 1. 기본 타입이거나 null인 경우 처리
+  // 2. 둘 다 객체인 경우
+  //    - 배열인지 확인
+  //    - 객체의 키 개수가 다른 경우 처리
+  //    - 재귀적으로 각 속성에 대해 deepEquals 호출
+
+  // 기본 타입일 때 값이 같거나, 같은 메모리 주소를 보고 있으면 true 처리
+  if (a === b) return true;
+
+  // 둘 중 하나라도 null이면 false처리
+  if (a === null || b === null) return false;
+
+  // 배열, 객체가 아니라면 false 리턴
+  if (typeof a !== "object" || typeof b !== "object") return false;
+
+  // 배열인지 확인
+  const isArrayA = Array.isArray(a);
+  const isArrayB = Array.isArray(b);
+
+  if (isArrayA !== isArrayB) return false;
+  if (isArrayA && isArrayB) {
+    // 길이 다르면 false
+    if (a.length !== b.length) return false;
+
+    // 배열의 각 요소를 재귀적으로 비교
+    // 요소가 배열, 객체일 수도 있으니까
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEquals(a[i], b[i])) return false;
+    }
+
+    return true;
+  }
+
+  // 객체인지 확인
+  const keysA = Object.keys(a as Record<string, unknown>);
+  const keysB = Object.keys(b as Record<string, unknown>);
+
+  // 객체의 길이가 다르면 리턴
+  if (keysA.length !== keysB.length) return false;
+
+  for (let i = 0; i < keysA.length; i++) {
+    const currentKey = keysA[i];
+
+    // a의 key가 b에도 있는지 확인, 없으면 -> false
+    if (!Object.prototype.hasOwnProperty.call(b, currentKey)) return false;
+
+    if (!deepEquals((a as Record<string, unknown>)[currentKey], (b as Record<string, unknown>)[currentKey]))
+      return false;
+  }
+
+  return true;
 };

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,32 +1,30 @@
-// 두 값의 깊은 비교를 수행합니다
+/**
+ * deepEquals - 두 값의 깊은 비교를 수행합니다.
+ *
+ * 특징:
+ * - 중첩된 객체와 배열의 모든 속성을 재귀적으로 비교
+ * - 기본 타입, null, undefined 처리
+ * - 배열과 객체의 구조적 동등성 검사
+ *
+ * @param a 비교할 첫 번째 값
+ * @param b 비교할 두 번째 값
+ * @returns 두 값이 깊게 동등하면 true, 아니면 false
+ */
 
 export const deepEquals = (a: unknown, b: unknown) => {
-  // 1. 기본 타입이거나 null인 경우 처리
-  // 2. 둘 다 객체인 경우
-  //    - 배열인지 확인
-  //    - 객체의 키 개수가 다른 경우 처리
-  //    - 재귀적으로 각 속성에 대해 deepEquals 호출
-
-  // 기본 타입일 때 값이 같거나, 같은 메모리 주소를 보고 있으면 true 처리
   if (a === b) return true;
 
-  // 둘 중 하나라도 null이면 false처리
   if (a === null || b === null) return false;
 
-  // 배열, 객체가 아니라면 false 리턴
   if (typeof a !== "object" || typeof b !== "object") return false;
 
-  // 배열인지 확인
   const isArrayA = Array.isArray(a);
   const isArrayB = Array.isArray(b);
 
   if (isArrayA !== isArrayB) return false;
   if (isArrayA && isArrayB) {
-    // 길이 다르면 false
     if (a.length !== b.length) return false;
 
-    // 배열의 각 요소를 재귀적으로 비교
-    // 요소가 배열, 객체일 수도 있으니까
     for (let i = 0; i < a.length; i++) {
       if (!deepEquals(a[i], b[i])) return false;
     }
@@ -34,17 +32,14 @@ export const deepEquals = (a: unknown, b: unknown) => {
     return true;
   }
 
-  // 객체인지 확인
   const keysA = Object.keys(a as Record<string, unknown>);
   const keysB = Object.keys(b as Record<string, unknown>);
 
-  // 객체의 길이가 다르면 리턴
   if (keysA.length !== keysB.length) return false;
 
   for (let i = 0; i < keysA.length; i++) {
     const currentKey = keysA[i];
 
-    // a의 key가 b에도 있는지 확인, 없으면 -> false
     if (!Object.prototype.hasOwnProperty.call(b, currentKey)) return false;
 
     if (!deepEquals((a as Record<string, unknown>)[currentKey], (b as Record<string, unknown>)[currentKey]))

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,3 +1,29 @@
-export const shallowEquals = (a: unknown, b: unknown) => {
-  return a === b;
+export const shallowEquals = (objA: unknown, objB: unknown): boolean => {
+  // 객체가 다르면 false 리턴
+  if (typeof objA !== "object" || objA === null || typeof objB !== "object" || objB === null) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  // 길이가 다르면 false 리턴
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // A 키를 기준으로 B에 같은 키가 있는지, 그리고 그 값이 있는지 확인
+  // Object.prototype.hasOwnProperty.call() => 객체가 해당 속성을 직접 소유하고 있는지 확인
+  for (let i = 0; i < keysA.length; i++) {
+    const currentKey = keysA[i];
+
+    if (
+      !Object.prototype.hasOwnProperty.call(objB, currentKey) ||
+      !Object.is((objA as Record<string, unknown>)[currentKey], (objB as Record<string, unknown>)[currentKey])
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 };

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,6 +1,4 @@
 export const shallowEquals = (a: unknown, b: unknown): boolean => {
-  // 객체가 다르면 false 리턴
-
   if (Object.is(a, b)) {
     return true;
   }
@@ -9,8 +7,8 @@ export const shallowEquals = (a: unknown, b: unknown): boolean => {
     return false;
   }
 
-  const keysA = Object.keys(a);
-  const keysB = Object.keys(b);
+  const keysA = Object.keys(a as Record<string, unknown>);
+  const keysB = Object.keys(b as Record<string, unknown>);
 
   // 길이가 다르면 false 리턴
   if (keysA.length !== keysB.length) {

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,3 +1,16 @@
+/**
+ * shallowEquals - 두 값의 얕은 비교를 수행합니다.
+ *
+ * 특징:
+ * - 객체의 첫 번째 깊이 속성들만 비교 (중첩 객체는 참조 비교)
+ * - Object.is()를 사용하여 정확한 값 비교
+ * - React의 최적화에서 주로 사용되는 비교 방식
+ *
+ * @param a 비교할 첫 번째 값
+ * @param b 비교할 두 번째 값
+ * @returns 두 값이 얕게 동등하면 true, 아니면 false
+ */
+
 export const shallowEquals = (a: unknown, b: unknown): boolean => {
   if (Object.is(a, b)) {
     return true;
@@ -10,13 +23,10 @@ export const shallowEquals = (a: unknown, b: unknown): boolean => {
   const keysA = Object.keys(a as Record<string, unknown>);
   const keysB = Object.keys(b as Record<string, unknown>);
 
-  // 길이가 다르면 false 리턴
   if (keysA.length !== keysB.length) {
     return false;
   }
 
-  // A 키를 기준으로 B에 같은 키가 있는지, 그리고 그 값이 있는지 확인
-  // Object.prototype.hasOwnProperty.call() => 객체가 해당 속성을 직접 소유하고 있는지 확인
   for (let i = 0; i < keysA.length; i++) {
     const currentKey = keysA[i];
 

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,11 +1,16 @@
-export const shallowEquals = (objA: unknown, objB: unknown): boolean => {
+export const shallowEquals = (a: unknown, b: unknown): boolean => {
   // 객체가 다르면 false 리턴
-  if (typeof objA !== "object" || objA === null || typeof objB !== "object" || objB === null) {
+
+  if (Object.is(a, b)) {
+    return true;
+  }
+
+  if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) {
     return false;
   }
 
-  const keysA = Object.keys(objA);
-  const keysB = Object.keys(objB);
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
 
   // 길이가 다르면 false 리턴
   if (keysA.length !== keysB.length) {
@@ -18,8 +23,8 @@ export const shallowEquals = (objA: unknown, objB: unknown): boolean => {
     const currentKey = keysA[i];
 
     if (
-      !Object.prototype.hasOwnProperty.call(objB, currentKey) ||
-      !Object.is((objA as Record<string, unknown>)[currentKey], (objB as Record<string, unknown>)[currentKey])
+      !Object.prototype.hasOwnProperty.call(b, currentKey) ||
+      !Object.is((a as Record<string, unknown>)[currentKey], (b as Record<string, unknown>)[currentKey])
     ) {
       return false;
     }

--- a/packages/lib/src/hocs/deepMemo.ts
+++ b/packages/lib/src/hocs/deepMemo.ts
@@ -2,8 +2,18 @@ import type { FunctionComponent } from "react";
 import { deepEquals } from "../equals";
 import { memo } from "./memo";
 
+/**
+ * deepMemo - deep comparison을 사용하여 컴포넌트를 메모이제이션하는 HOC입니다.
+ *
+ * 특징:
+ * - props의 deep comparison을 통해 리렌더링 최적화
+ * - 중첩된 객체나 배열의 내부 값까지 비교
+ * - React.memo보다 더 세밀한 비교로 불필요한 리렌더링 방지
+ *
+ * @param Component 메모이제이션할 함수형 컴포넌트
+ * @returns 최적화된 메모이제이션된 컴포넌트
+ */
+
 export function deepMemo<P extends object>(Component: FunctionComponent<P>) {
-  // deepEquals 함수를 사용하여 props 비교
-  // 앞에서 만든 memo를 사용
   return memo(Component, deepEquals);
 }

--- a/packages/lib/src/hocs/deepMemo.ts
+++ b/packages/lib/src/hocs/deepMemo.ts
@@ -1,5 +1,9 @@
 import type { FunctionComponent } from "react";
+import { deepEquals } from "../equals";
+import { memo } from "./memo";
 
 export function deepMemo<P extends object>(Component: FunctionComponent<P>) {
-  return Component;
+  // deepEquals 함수를 사용하여 props 비교
+  // 앞에서 만든 memo를 사용
+  return memo(Component, deepEquals);
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -1,6 +1,28 @@
-import { type FunctionComponent } from "react";
+import { type FunctionComponent, type ReactNode } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "../hooks";
 
+// memo HOC는 컴포넌트의 props를 얕은 비교하여 불필요한 리렌더링을 방지합니다.
 export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
-  return Component;
+  // 1. 이전 props를 저장할 ref 생성
+  // 2. 메모이제이션된 컴포넌트 생성
+  // 3. equals 함수를 사용하여 props 비교
+  // 4. props가 변경된 경우에만 새로운 렌더링 수행
+  const MemoizedComponent = (currentProps: P) => {
+    const prevProps = useRef<P | null>(null); // 이전 프롭스들
+    const prevResult = useRef<ReactNode | Promise<ReactNode> | null>(null); // 이전 렌더링 결과
+
+    if (!equals(prevProps.current, currentProps)) {
+      // props가 변경되었을 때 -> 새로 값 부여
+      const currentResult = Component(currentProps);
+      prevProps.current = currentProps;
+      prevResult.current = currentResult;
+      return currentResult;
+    } else {
+      // props가 그대로일 때 -> 이전 result를 리턴
+      return prevResult.current!;
+    }
+  };
+
+  return MemoizedComponent;
 }

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -2,23 +2,26 @@ import type { AnyFunction } from "../types";
 import { useCallback } from "./useCallback";
 import { useRef } from "./useRef";
 
-// useCallback과 useRef를 이용하여 useAutoCallback
-// 콜백함수가 참조하는 값은 항상 렌더링 시점에 최신화 되어야 한다. ← 이 부분을 어떻게 해결할 수 있을지 고민해보세요!
-// 대신 항상 동일한 참조를 유지해야 한다 (useCallback 활용)
+/**
+ * useAutoCallback - 함수 참조는 고정하면서 내부에서는 최신 값에 접근하는 콜백을 생성합니다.
+ *
+ * 특징:
+ * - 함수 참조가 항상 동일하게 유지됨 (=== 비교에서 항상 true)
+ * - 함수 내부에서는 closure 문제 없이 최신 state/props에 접근
+ * - dependency 배열이 필요 없음
+ *
+ * @param fn 래핑할 함수
+ * @returns 최적화된 콜백 함수
+ */
 
-// "함수 참조는 항상 동일하게 유지하면서, 함수 내부에서는 항상 최신 값에 접근하자!"
-// 함수 참조 고정: === 비교에서 항상 true
-// 최신 값 접근: closure 문제 없이 최신 state/props 사
-
-// 항상 같은 함수!!!!!인데, 내부에서는 최신 값을 봄!!!!
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
-  // 최신 함수 저장하기
+  // 최신 함수를 참조하는 ref
   const currentFn = useRef(fn);
-  currentFn.current = fn; // 항상 최신 유지
+  currentFn.current = fn;
 
-  // useCallback으로 바뀌지 않는 래퍼 함수 생성
+  // 동일한 참조를 유지하는 래퍼 함수
   const wrapper = useCallback((...args: Parameters<T>): ReturnType<T> => {
-    return currentFn.current(...args); // 최신 함수 실행
+    return currentFn.current(...args);
   }, []) as T;
 
   return wrapper;

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -2,6 +2,24 @@ import type { AnyFunction } from "../types";
 import { useCallback } from "./useCallback";
 import { useRef } from "./useRef";
 
+// useCallback과 useRef를 이용하여 useAutoCallback
+// 콜백함수가 참조하는 값은 항상 렌더링 시점에 최신화 되어야 한다. ← 이 부분을 어떻게 해결할 수 있을지 고민해보세요!
+// 대신 항상 동일한 참조를 유지해야 한다 (useCallback 활용)
+
+// "함수 참조는 항상 동일하게 유지하면서, 함수 내부에서는 항상 최신 값에 접근하자!"
+// 함수 참조 고정: === 비교에서 항상 true
+// 최신 값 접근: closure 문제 없이 최신 state/props 사
+
+// 항상 같은 함수!!!!!인데, 내부에서는 최신 값을 봄!!!!
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
-  return fn;
+  // 최신 함수 저장하기
+  const currentFn = useRef(fn);
+  currentFn.current = fn; // 항상 최신 유지
+
+  // useCallback으로 바뀌지 않는 래퍼 함수 생성
+  const wrapper = useCallback((...args: Parameters<T>): ReturnType<T> => {
+    return currentFn.current(...args); // 최신 함수 실행
+  }, []) as T;
+
+  return wrapper;
 };

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import type { DependencyList } from "react";
 import { useMemo } from "./useMemo";
 

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
 import type { DependencyList } from "react";
+import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
   // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  return useMemo(() => factory, _deps);
 }

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -3,6 +3,5 @@ import type { DependencyList } from "react";
 import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
-  // 직접 작성한 useMemo를 통해서 만들어보세요.
   return useMemo(() => factory, _deps);
 }

--- a/packages/lib/src/hooks/useDeepMemo.ts
+++ b/packages/lib/src/hooks/useDeepMemo.ts
@@ -4,6 +4,5 @@ import { useMemo } from "./useMemo";
 import { deepEquals } from "../equals";
 
 export function useDeepMemo<T>(factory: () => T, deps: DependencyList): T {
-  // 직접 작성한 useMemo를 참고해서 만들어보세요.
   return useMemo(factory, deps, deepEquals);
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import type { DependencyList } from "react";
 import { shallowEquals } from "../equals";
 import { useRef } from "./useRef";

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -2,22 +2,26 @@ import type { DependencyList } from "react";
 import { shallowEquals } from "../equals";
 import { useRef } from "./useRef";
 
-// useMemo 훅은 계산 비용이 높은 값을 메모이제이션합니다.
-
+/**
+ * useMemo - 계산 비용이 높은 값을 메모이제이션합니다.
+ *
+ * @param factory 메모이제이션할 값을 계산하는 함수
+ * @param _deps 의존성 배열
+ * @param _equals 의존성 비교 함수 (기본값: shallowEquals)
+ * @returns 메모이제이션된 값
+ */
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요! 이게 제일 중요합니다.
-
-  // 1. 이전 의존성과 결과를 저장할 ref 생성
+  // 이전 의존성과 계산 결과를 저장할 캐시
   const cache = useRef<{ deps: DependencyList | null; result: T | null }>({
-    deps: null, // 이전 의존성
-    result: null, // 결과
+    deps: null,
+    result: null,
   });
 
-  // 2. 현재 의존성과 이전 의존성 비교
-  const prevDeps = cache.current.deps; // 이전 값
-  const hasChanged = prevDeps === null || !_equals(prevDeps, _deps); // prevDeps가 null 이거나 얕은 비교가 성공했을 때
+  // 의존성 변경 여부 확인
+  const prevDeps = cache.current.deps;
+  const hasChanged = prevDeps === null || !_equals(prevDeps, _deps);
 
-  // 3. 의존성이 변경된 경우 factory 함수 실행 및 결과 저장
+  // 의존성이 변경된 경우에만 factory 함수 실행
   if (hasChanged) {
     const newResult = factory();
     cache.current = {
@@ -26,8 +30,5 @@ export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = sh
     };
   }
 
-  // 4. 메모이제이션된 값 반환
-
-  // 구현을 완성해주세요.
-  return cache.current.result!; // 이 부분을 적절히 수정하세요.
+  return cache.current.result!;
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -1,8 +1,34 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { DependencyList } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "./useRef";
+
+// useMemo 훅은 계산 비용이 높은 값을 메모이제이션합니다.
 
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+  // 직접 작성한 useRef를 통해서 만들어보세요! 이게 제일 중요합니다.
+
+  // 1. 이전 의존성과 결과를 저장할 ref 생성
+  const cache = useRef<{ deps: DependencyList | null; result: T | null }>({
+    deps: null, // 이전 의존성
+    result: null, // 결과
+  });
+
+  // 2. 현재 의존성과 이전 의존성 비교
+  const prevDeps = cache.current.deps; // 이전 값
+  const hasChanged = prevDeps === null || !_equals(prevDeps, _deps); // prevDeps가 null 이거나 얕은 비교가 성공했을 때
+
+  // 3. 의존성이 변경된 경우 factory 함수 실행 및 결과 저장
+  if (hasChanged) {
+    const newResult = factory();
+    cache.current = {
+      deps: _deps,
+      result: newResult,
+    };
+  }
+
+  // 4. 메모이제이션된 값 반환
+
+  // 구현을 완성해주세요.
+  return cache.current.result!; // 이 부분을 적절히 수정하세요.
 }

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,4 +1,17 @@
+// useRef 혹인 렌더링 사이에 값을 유지하는 가변 ref 객체를 생성합니다.
+// 리액트의 컴포넌트는 state가 변경되거나 props가 바뀔 때마다 다시 렌더링 된다
+// 이때 함수 컴포넌트는 처음부터 끝까지 다시 실행
+// let someValue = 0; <- 매번 렌더 될 때마다 0으로 초기화됨
+// useState로 만든 state는 불변. 값을 바꾸려면 setState를 호출해야 하고, 이건 리랜더링을 일으킴
+// useRef의 current 프로퍼티는 직접 수정할 수 있고, 수정해도 리렌더링이 일어나지 않다.
+// DOM Element 참조 외에, 이전 state값을 기억하고 싶을 때, setInterval, setTimeout 등 ID 저장해서 나중에 clear 할 때
+// 리렌더링을 일으키지 않으면서 값을 계속 유지하고 싶을 때, 함수와 참조 유지할 때
+
+import { useState } from "react";
+
 export function useRef<T>(initialValue: T): { current: T } {
   // useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  const [refObject] = useState(() => ({ current: initialValue }));
+
+  return refObject;
 }

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -11,6 +11,9 @@ import { useState } from "react";
 
 export function useRef<T>(initialValue: T): { current: T } {
   // useState를 이용해서 만들어보세요.
+  // 리액트에서는 각 컴포넌트 인스턴스마다 독립적인 메모리 공간을 관리하고, useState는 그 메모리 공간에 값을 저장해 준다 -> 컴포넌트마다 따로 독립적인 값을 가질 수 있는 이유
+  // 리랜더링할 때마다 초기화로 변경되지 않고, 다른 컴포넌트와도 값이 공유되지 않아서
+  // 이런 점을 이용해 useRef를 구현할 수 있다!
   const [refObject] = useState(() => ({ current: initialValue }));
 
   return refObject;

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,19 +1,21 @@
-// useRef 혹인 렌더링 사이에 값을 유지하는 가변 ref 객체를 생성합니다.
-// 리액트의 컴포넌트는 state가 변경되거나 props가 바뀔 때마다 다시 렌더링 된다
-// 이때 함수 컴포넌트는 처음부터 끝까지 다시 실행
-// let someValue = 0; <- 매번 렌더 될 때마다 0으로 초기화됨
-// useState로 만든 state는 불변. 값을 바꾸려면 setState를 호출해야 하고, 이건 리랜더링을 일으킴
-// useRef의 current 프로퍼티는 직접 수정할 수 있고, 수정해도 리렌더링이 일어나지 않다.
-// DOM Element 참조 외에, 이전 state값을 기억하고 싶을 때, setInterval, setTimeout 등 ID 저장해서 나중에 clear 할 때
-// 리렌더링을 일으키지 않으면서 값을 계속 유지하고 싶을 때, 함수와 참조 유지할 때
-
 import { useState } from "react";
 
+/**
+ * useRef - 렌더링 사이에 값을 유지하는 가변 ref 객체를 생성합니다.
+ *
+ * 특징:
+ * - current 프로퍼티는 직접 수정 가능하며, 수정해도 리렌더링이 발생하지 않음
+ * - useState와 달리 값 변경 시 컴포넌트가 다시 렌더링되지 않음
+ *
+ * 사용 사례:
+ * - DOM 요소 참조
+ * - 이전 state 값 기억
+ * - 타이머 ID 저장 (setInterval, setTimeout)
+ * - 리렌더링 없이 값을 유지해야 하는 경우
+ * - 함수 참조 유지
+ */
+
 export function useRef<T>(initialValue: T): { current: T } {
-  // useState를 이용해서 만들어보세요.
-  // 리액트에서는 각 컴포넌트 인스턴스마다 독립적인 메모리 공간을 관리하고, useState는 그 메모리 공간에 값을 저장해 준다 -> 컴포넌트마다 따로 독립적인 값을 가질 수 있는 이유
-  // 리랜더링할 때마다 초기화로 변경되지 않고, 다른 컴포넌트와도 값이 공유되지 않아서
-  // 이런 점을 이용해 useRef를 구현할 수 있다!
   const [refObject] = useState(() => ({ current: initialValue }));
 
   return refObject;

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -5,10 +5,21 @@ import { useShallowSelector } from "./useShallowSelector";
 
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 
+/**
+ * useRouter - 라우터 상태를 구독하고 선택적으로 데이터를 추출하는 훅입니다.
+ *
+ * 특징:
+ * - useSyncExternalStore를 사용하여 라우터 상태 변경을 감지
+ * - selector를 통해 필요한 데이터만 선택적으로 추출 가능
+ * - shallow comparison을 통한 최적화된 리렌더링
+ *
+ * @param router 구독할 라우터 인스턴스
+ * @param selector 상태에서 필요한 값을 선택하는 함수 (기본값: 전체 상태 반환)
+ * @returns 선택된 라우터 상태
+ */
+
 export const useRouter = <T extends RouterInstance<AnyFunction>, S>(router: T, selector = defaultSelector<T, S>) => {
-  // useSyncExternalStore를 사용하여 router의 상태를 구독하고 가져오는 훅을 구현합니다.
   const shallowSelector = useShallowSelector(selector);
-  // useSyncExternalStore 두 번째 인자(현재상태)는 "전체 상태"를 반환해야 함
   const state = useSyncExternalStore(router.subscribe, () => shallowSelector(router));
   return state;
 };

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -8,5 +8,7 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 export const useRouter = <T extends RouterInstance<AnyFunction>, S>(router: T, selector = defaultSelector<T, S>) => {
   // useSyncExternalStore를 사용하여 router의 상태를 구독하고 가져오는 훅을 구현합니다.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(router);
+  // useSyncExternalStore 두 번째 인자(현재상태)는 "전체 상태"를 반환해야 함
+  const state = useSyncExternalStore(router.subscribe, () => shallowSelector(router));
+  return state;
 };

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -5,5 +5,21 @@ type Selector<T, S = T> = (state: T) => S;
 
 export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
   // 이전 상태를 저장하고, shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
-  return (state: T): S => selector(state);
+  // useRef로 이전 값 기억
+  // shallowEquals로 얕은 비교로 변경 감지
+  // 같으면 -> 이전 값 반환 (리랜더링 안 함)
+  // 다르면 -> 새로운 값 반환 + 값을 previous에 저장
+
+  const previousRef = useRef<S>(null);
+
+  return (state: T): S => {
+    const newValue = selector(state);
+
+    if (previousRef.current !== null && shallowEquals(previousRef.current, newValue)) {
+      return previousRef.current;
+    }
+
+    previousRef.current = newValue;
+    return newValue;
+  };
 };

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -3,13 +3,19 @@ import { shallowEquals } from "../equals";
 
 type Selector<T, S = T> = (state: T) => S;
 
-export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
-  // 이전 상태를 저장하고, shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
-  // useRef로 이전 값 기억
-  // shallowEquals로 얕은 비교로 변경 감지
-  // 같으면 -> 이전 값 반환 (리랜더링 안 함)
-  // 다르면 -> 새로운 값 반환 + 값을 previous에 저장
+/**
+ * useShallowSelector - selector 함수를 shallow comparison으로 최적화하는 훅입니다.
+ *
+ * 특징:
+ * - 이전 결과와 shallow comparison을 통해 불필요한 리렌더링 방지
+ * - 같은 값이면 이전 참조를 유지하여 === 비교에서 true 반환
+ * - 값이 변경된 경우에만 새로운 참조 반환
+ *
+ * @param selector 상태에서 값을 선택하는 함수
+ * @returns 최적화된 selector 함수
+ */
 
+export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
   const previousRef = useRef<S>(null);
 
   return (state: T): S => {

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -12,18 +12,21 @@ export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[
   // 실제로 값이 변경되었을 때만 함수가 실행되게
   // 근데 newSetter 쓰면 매번 새로운 함수가 호출되어서 (마지막 테스트 실패)
   // useCallback으로 함수를 메모이제이션
-  const newSetter = useCallback((newValue: Parameters<typeof useState<T>>[0]) => {
-    // 여기에서 shallowEquals 검사
-    // 정말 바뀌었을 때만 setValue 호출
+  const newSetter = useCallback(
+    (newValue: Parameters<typeof useState<T>>[0]) => {
+      // 여기에서 shallowEquals 검사
+      // 정말 바뀌었을 때만 setValue 호출
 
-    setValue((currentValue) => {
-      if (!shallowEquals(value, newValue)) {
-        return newValue;
-      }
+      setValue((currentValue) => {
+        if (!shallowEquals(value, newValue)) {
+          return newValue;
+        }
 
-      return currentValue;
-    });
-  }, []);
+        return currentValue;
+      });
+    },
+    [value],
+  );
 
   return [value, newSetter];
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,7 +1,29 @@
 import { useState } from "react";
 import { shallowEquals } from "../equals";
+import { useCallback } from "./useCallback";
 
 export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
   // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
-  return useState(initialValue);
+  // 실제로 내용이 바뀌었을 때만 렌더링 하는 용도
+  // 일반 useState 는 참조 비교로 === 쓰는데, useShallowState는 내가 구현한 shallowEquals 쓰도록
+
+  const [value, setValue] = useState(initialValue);
+
+  // 실제로 값이 변경되었을 때만 함수가 실행되게
+  // 근데 newSetter 쓰면 매번 새로운 함수가 호출되어서 (마지막 테스트 실패)
+  // useCallback으로 함수를 메모이제이션
+  const newSetter = useCallback((newValue: Parameters<typeof useState<T>>[0]) => {
+    // 여기에서 shallowEquals 검사
+    // 정말 바뀌었을 때만 setValue 호출
+
+    setValue((currentValue) => {
+      if (!shallowEquals(value, newValue)) {
+        return newValue;
+      }
+
+      return currentValue;
+    });
+  }, []);
+
+  return [value, newSetter];
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -12,21 +12,18 @@ export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[
   // 실제로 값이 변경되었을 때만 함수가 실행되게
   // 근데 newSetter 쓰면 매번 새로운 함수가 호출되어서 (마지막 테스트 실패)
   // useCallback으로 함수를 메모이제이션
-  const newSetter = useCallback(
-    (newValue: Parameters<typeof useState<T>>[0]) => {
-      // 여기에서 shallowEquals 검사
-      // 정말 바뀌었을 때만 setValue 호출
+  const newSetter = useCallback((newValue: Parameters<typeof useState<T>>[0]) => {
+    // 여기에서 shallowEquals 검사
+    // 정말 바뀌었을 때만 setValue 호출
 
-      setValue((currentValue) => {
-        if (!shallowEquals(value, newValue)) {
-          return newValue;
-        }
+    setValue((currentValue) => {
+      if (!shallowEquals(value, newValue)) {
+        return newValue;
+      }
 
-        return currentValue;
-      });
-    },
-    [value],
-  );
+      return currentValue;
+    });
+  }, []);
 
   return [value, newSetter];
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -2,25 +2,26 @@ import { useState } from "react";
 import { shallowEquals } from "../equals";
 import { useCallback } from "./useCallback";
 
-export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
-  // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
-  // 실제로 내용이 바뀌었을 때만 렌더링 하는 용도
-  // 일반 useState 는 참조 비교로 === 쓰는데, useShallowState는 내가 구현한 shallowEquals 쓰도록
+/**
+ * useShallowState - shallow comparison을 통해 최적화된 state 관리 훅입니다.
+ *
+ * 특징:
+ * - 일반 useState와 달리 shallow comparison으로 변경 감지
+ * - 실제 내용이 바뀌었을 때만 리렌더링 발생
+ * - 객체나 배열의 내부 값이 같으면 리렌더링하지 않음
+ *
+ * @param initialValue 초기 상태값
+ * @returns [현재값, setter함수] 튜플
+ */
 
+export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
   const [value, setValue] = useState(initialValue);
 
-  // 실제로 값이 변경되었을 때만 함수가 실행되게
-  // 근데 newSetter 쓰면 매번 새로운 함수가 호출되어서 (마지막 테스트 실패)
-  // useCallback으로 함수를 메모이제이션
   const newSetter = useCallback((newValue: Parameters<typeof useState<T>>[0]) => {
-    // 여기에서 shallowEquals 검사
-    // 정말 바뀌었을 때만 setValue 호출
-
     setValue((currentValue) => {
       if (!shallowEquals(value, newValue)) {
         return newValue;
       }
-
       return currentValue;
     });
   }, []);

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -5,5 +5,11 @@ type Storage<T> = ReturnType<typeof createStorage<T>>;
 
 export const useStorage = <T>(storage: Storage<T>) => {
   // useSyncExternalStore를 사용해서 storage의 상태를 구독하고 가져오는 훅을 구현해보세요.
-  return storage.get();
+
+  // storage는 createStorage 함수가 반환하는 객체
+  // get, set, reset, subscribe 리턴
+
+  const state = useSyncExternalStore(storage.subscribe, () => storage.get());
+
+  return state;
 };

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -3,13 +3,19 @@ import type { createStorage } from "../createStorage";
 
 type Storage<T> = ReturnType<typeof createStorage<T>>;
 
+/**
+ * useStorage - storage 상태를 구독하고 가져오는 훅입니다.
+ *
+ * 특징:
+ * - useSyncExternalStore를 사용하여 external storage 상태 구독
+ * - storage 값이 변경될 때마다 자동으로 컴포넌트 리렌더링
+ * - createStorage로 생성된 storage 객체와 함께 사용
+ *
+ * @param storage createStorage로 생성된 storage 객체
+ * @returns 현재 storage 값
+ */
+
 export const useStorage = <T>(storage: Storage<T>) => {
-  // useSyncExternalStore를 사용해서 storage의 상태를 구독하고 가져오는 훅을 구현해보세요.
-
-  // storage는 createStorage 함수가 반환하는 객체
-  // get, set, reset, subscribe 리턴
-
   const state = useSyncExternalStore(storage.subscribe, () => storage.get());
-
   return state;
 };

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -9,5 +9,5 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 export const useStore = <T, S = T>(store: Store<T>, selector: (state: T) => S = defaultSelector<T, S>) => {
   // useSyncExternalStore와 useShallowSelector를 사용해서 store의 상태를 구독하고 가져오는 훅을 구현해보세요.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(store.getState());
+  return useSyncExternalStore(store.subscribe, () => shallowSelector(store.getState()));
 };

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -6,8 +6,20 @@ type Store<T> = ReturnType<typeof createStore<T>>;
 
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 
+/**
+ * useStore - store 상태를 구독하고 선택적으로 데이터를 추출하는 훅입니다.
+ *
+ * 특징:
+ * - useSyncExternalStore를 사용하여 store 상태 변경 감지
+ * - selector를 통해 필요한 데이터만 선택적으로 추출
+ * - shallow comparison을 통한 최적화된 리렌더링
+ *
+ * @param store createStore로 생성된 store 객체
+ * @param selector 상태에서 필요한 값을 선택하는 함수 (기본값: 전체 상태 반환)
+ * @returns 선택된 store 상태
+ */
+
 export const useStore = <T, S = T>(store: Store<T>, selector: (state: T) => S = defaultSelector<T, S>) => {
-  // useSyncExternalStore와 useShallowSelector를 사용해서 store의 상태를 구독하고 가져오는 훅을 구현해보세요.
   const shallowSelector = useShallowSelector(selector);
   return useSyncExternalStore(store.subscribe, () => shallowSelector(store.getState()));
 };


### PR DESCRIPTION
## 과제 체크포인트

### 배포 링크

https://eveneul.github.io/front_6th_chapter1-3/

<!--
배포 링크를 적어주세요
예시: https://<username>.github.io/front-6th-chapter1-3/

배포가 완료되지 않으면 과제를 통과할 수 없습니다.
배포 후에 정상 작동하는지 확인해주세요.
-->

### 기본과제

### equalities

- [x]  shallowEquals 구현 완료
- [x]  deepEquals 구현 완료

### hooks

- [x]  useRef 구현 완료
- [x]  useMemo 구현 완료
- [x]  useCallback 구현 완료
- [x]  useDeepMemo 구현 완료
- [x]  useShallowState 구현 완료
- [x]  useAutoCallback 구현 완료

### High Order Components

- [x]  memo 구현 완료
- [x]  deepMemo 구현 완료

### 심화 과제

### hooks

- [x]  createObserver를 useSyncExternalStore에 사용하기 적합한 코드로 개선
- [x]  useShallowSelector 구현
- [x]  useStore 구현
- [x]  useRouter 구현
- [x]  useStorage 구현

### context

- [x]  ToastContext, ModalContext 개선

## 과제 셀프회고

<!-- 과제에 대한 회고를 작성해주세요 -->

### 기술적 성장

<!-- 예시

- 새로 학습한 개념
- 기존 지식의 재발견/심화
- 구현 과정에서의 기술적 도전과 해결
-->

1주차부터 3주차까지 자바스크립트를 나름대로 딥 다이브 한 것 같다. 프레임워크 없이 SPA 만들기는 정말 생각하지도 못했고, **리액트를 사용하면서 이건 자바스크립트로 어떻게 굴러가는 거지?** 라는 생각을 개발 시장에 뛰어든 지 3년에서야 하게 되었다. ~~이것 참 부끄러운 일이다..~~

각설하고, 기술적인 성장을 나열하자면 아래와 같다.

- [얕은 비교/깊은 비교] `Object.is`를 처음 봤다.

동등 연산자, 일치 연산자와의 차이도 알았다. 대신 이해는 조금 어려웠다. 타입까지 분별해 주기에 일치 연산자를 쓰라고 권장하기에 일치 연산자가 만능인 줄 알았다. 그런데 그게 객체에서는 적용이 안 되는 줄은 몰랐다.

객체는 참조형 타입이므로 일치 연산자로 비교를 했을 때, 메모리 주소값으로 비교를 하기 때문에 key-value값을 확인하지 못하기에 Object.keys를 통해 반복문을 돌면서 Object.is로 key, value가 같은지 확인했다.

```jsx
  const keysA = Object.keys(a as Record<string, unknown>);
  const keysB = Object.keys(b as Record<string, unknown>);

  // 길이가 다르면 false 리턴
  if (keysA.length !== keysB.length) {
    return false;
  }

  // A 키를 기준으로 B에 같은 키가 있는지, 그리고 그 값이 있는지 확인
  // Object.prototype.hasOwnProperty.call() => 객체가 해당 속성을 직접 소유하고 있는지 확인
  for (let i = 0; i < keysA.length; i++) {
    const currentKey = keysA[i];

    if (
      !Object.prototype.hasOwnProperty.call(b, currentKey) ||
      !Object.is((a as Record<string, unknown>)[currentKey], (b as Record<string, unknown>)[currentKey])
    ) {
      return false;
    }
  }
```

`Object.prototype.hasDownProperty.call`로 B 객체에 A가 가지고 있는 키가 없거나, Object.is로 두 값의 key가 일치하지 않으면 두 오브젝트는 같지 않다고 반환해 주었다.

- [useRef] useState 초기값에 왜 { current: initialValue }를 넣으면 안 될까?

`useRef`는 **렌더링에 필요하지 않은 값을 참조**할 수 있다. **initialValue에 값을 넣으면 초기 렌더링 이후부터는 무시된다**. 같은 값을 유지해야 하는 방법은 아래와 같다.

- useState: 상태 유지
- useRef: 참조 유지 (그런데 이걸 만들어야 하니까 쓸 수 없음)
- useMemo: 계산 결과 유지
- useReducer: 복잡한 상태 유지

useMemo는 복잡한 계산을 캐싱해서 성능을 최적화시키는 건데, 생각보다 많은 데에 쓰일 useRef를 만들 때 useMemo를 쓰는 게 맞나? 싶었다. 잘못 사용하면 성능이 더 안 좋아진다. useReducer는 너무 복잡했다. 그래서 useState로 만들었다.

**그런데 한 가지 더 의문이 생겼다.** 왜 `useState({ current: initialValue })`는 안 되고, `useState(() ⇒ { current: initialValue })`는 되는 것일까? 

useState에게 직접적으로 부여한 객체(값)은 랜더링 될 때마다 생성하고, 함수는 첫 랜더링 이후 다시 실행되지 않는다. 이 점이 useRef를 구현하는 데에 잘 맞는 것 같아서 useState를 사용했다.  

```jsx
function App() {
  const [count, setCount] = useState(0);
  console.log('🔥 컴포넌트가 실행되었습니다.');

  console.log('🏃 직접 객체 코드 실행 시작');
  const directObject = { current: 100 };
  console.log('🏃 직접 객체 생성됨::', directObject);

  console.log('👀 함수 코드 실행 시작');
  const [ref] = useState(() => {
    console.log(
      '🍀🍀🍀🍀🍀🍀🍀🍀 함수 내부 실행됨. 새 객체 생성 🍀🍀🍀🍀🍀🍀🍀🍀🍀'
    );
    return { current: 200 };
  });

  console.log('🫵 useState 완료 (직접 객체도, 함수 코드도)');

  return (
    <div className='App'>
      <span>개발자 도구 콘솔창을 열어서 결과를 확인해 보세요.</span>
      <button onClick={() => setCount(prev => prev + 1)}>
        리렌더링 시키기!
      </button>
    </div>
  );
}
```

결과는 여기에서 확인 가능하다. https://2473697.playcode.io/
(수민 공주.. 보고 있어..?) 

- useSyncExternalStore Hook에 대해서

리액트에서 전역 상태 관리는 Recoil, Zustand 같은 라이브러리를 사용해서 전역 상태에 대한 깊은 생각을 하지 않았었는데, 이번 과제를 통해 useSyncExternalStore 훅도 보고, 라이브러리를 직접 뜯어 볼 수 있어서 재미있었다. [관련한 내용은 벨로그를 통해 포스트 발행했다](https://velog.io/@eveneul/React.js-useSyncExternalStore%EB%9E%80-%EA%B7%B8%EB%A6%AC%EA%B3%A0-Zustand%EC%97%90%EC%84%9C-useSyncExternalStore%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%98%EB%8A%94-%EB%B0%A9%EC%8B%9D). 


### 자랑하고 싶은 코드

<!-- 예시

- 특히 만족스러운 구현
- 리팩토링이 필요한 부분
- 코드 설계 관련 고민과 결정
-->

```tsx
// createObserver.ts
export const createObserver = () => {
  const listeners = new Set<Listener>();

  // useSyncExternalStore 에서 활용할 수 있도록 subscribe 함수를 수정합니다.
  const subscribe = (fn: Listener) => {
    listeners.add(fn);

    return () => {
      listeners.delete(fn);
    };
  };

  const notify = () => listeners.forEach((listener) => listener());

  return { subscribe, notify };
};
```

사실 자랑하고 싶은 잘 짠 코드는 아니고, 내가 이해해서 과제를 수행했다! 를 보여 드리고 싶다. 실은 그간 보냈던 2주 동안에 listener에 대한 깊이 있는 이해가 부족해서 store를 구현하는 데에도 이게 왜 되지? 싶었는데, 이번 주차 과제를 통해 에라이~ 모르겠다! 하고 listener에 대해 좀 찾아봤다.

[관련한 벨로그 포스트도 발행했다.](https://velog.io/@eveneul/%EC%A0%84%EC%97%AD-%EC%83%81%ED%83%9C-%EA%B4%80%EB%A6%AC%EC%97%90%EC%84%9C-%EC%99%9C-listener-%EB%B0%B0%EC%97%B4%EC%9D%84-%EC%82%AC%EC%9A%A9%ED%95%A0%EA%B9%8C)

`unsubscribe` 함수를 삭제하고 `subscribe` 안에 `return () ⇒ { … }`로 추가했다. Zustand 같은 라이브러리를 사용한다면 알아서 메모리 누수를 방지하기 위해 구독 해제도 해 주지만, 생으로 store를 만들 때에는 다른 함수로 빼는 것이 아니라 같은 구독 함수 내에서 반환해 주어야 메모리 누수가 생기지 않는다.

### 개선이 필요하다고 생각하는 코드

<!-- 예시

- 특히 만족스러운 구현
- 리팩토링이 필요한 부분
- 코드 설계 관련 고민과 결정
-->

개선이 필요한 건 아니고, 왜 이렇게 돌아가는지 궁금했지만 (원래는 개인 회고 질문란에 넣을 생각이었다) 금주 준일 코치님 멘토링 시간에 해답을 찾았다.

```tsx
const defaultSelector = <T, S = T>(state: T) => state as unknown as S;

export const useRouter = <T extends RouterInstance<AnyFunction>, S>(router: T, selector = defaultSelector<T, S>) => {
  // useSyncExternalStore를 사용하여 router의 상태를 구독하고 가져오는 훅을 구현합니다.
  const shallowSelector = useShallowSelector(selector);
  // useSyncExternalStore 두 번째 인자(현재상태)는 "전체 상태"를 반환해야 함
  const state = useSyncExternalStore(router.subscribe, () => shallowSelector(router));
  return state;
};
```

`useSyncExternalStore`의 두 번째 인자로 현재 상태값을 넣어 줘야 하는 건 이해했다. 그런데 왜 `router.pathname`을 넣는 게 아닐지 궁금했다. **현재 상태값이라고 하면, 즉 router의 현재 상태값이라고 하면 pathname이 맞다고 생각했는데, 코치님께서는 아래와 같은 답변을 주셨다.**

```
pathname만 넘겨줘도 좋을 것 같긴 한데, 문제는 router 자체 대한 정보가 다 필요할 때가 있어서, 
pathname 뿐만 아니라 router 자체를 넘겨줘야 하지 않나!? 라고 생각이 되네요..!
```

이걸 듣고 앗.. 했다. 실제 (내가 사용할 때) 리액트에서 pathname을 얻을 때 `const router = useRouter()`로 선언해 준 뒤, router.pathname으로 접근하기도 하고, pathname만 얻는 거면 새로운 usePathname() 같은 걸 만들어 줘야 하지 않나? 결론은 닉값 하지 못한다. 라고 생각이 되었다.

### 학습 효과 분석

<!-- 예시

- 가장 큰 배움이 있었던 부분
- 추가 학습이 필요한 영역
- 실무 적용 가능성
-->
- 새로운 문법? 같은 걸 많이 만나 볼 수 있어서 좋았다. 앞서 작성했던 Object.is라든가, hasOwnProperty라든가, useSyncExternalStore 등..
- 스토어를 만들 때 왜 listener가 필요한지도 깊게 파고들 기회가 생겨서 좋았다. 그리고 일반 배열이 아닌 new Set으로 중복 방지를 해 주는 것까지!
- 실무 적용 가능성은 잘 모르겠다. 회사 바이 회사, 실무 바이 실무일 것 같다. 저희 회사는 개발 일감이 없어요.. 하.. 하지만 다른 프로젝트를 하거나, 다른 회사로 이직하게 된다면 useMemo, useCallback은 한두 번 정도 써먹을 수 있을 것 같다.

### 과제 피드백

<!-- 예시

- 과제에서 모호하거나 애매했던 부분
- 과제에서 좋았던 부분
-->
- 1, 2주차보다 재미있었습니다. 1주차는 UI를 직접 조작할 수 있었지만 첫 과제라는 부담감과 자바스크립트로 리액트를 직접 구현한 적이 없어서 어려웠고, 2주차는 알고리즘 성격의 로직 구현이 있어서 제 뇌로는 한계가 있는 것 같았지만.. 1, 2주차로부터 얻은 (얕은) 지식으로 충분히 풀어나갈 수 있어서 일찍 과제를 마치고(제일 중요) 저녁 약속도 잡았습니다.(이게 더 중요) 🍺
- 결론: 1, 2주차를 경험했어서, 3주차 과제가 수월할 수 있었습니다.

## 학습 갈무리

### 리액트의 렌더링이 어떻게 이루어지는지 정리해주세요.

<!-- 예시

- 리액트의 렌더링 과정
- 리액트의 렌더링 최적화 방법
- 리액트의 렌더링과 관련된 개념들 (예: Virtual DOM, Reconciliation 등)
- 리액트의 렌더링과 관련된 라이프사이클 메서드
- 리액트의 렌더링과 관련된 Hooks (예: useMemo, useCallback 등)
-->
- 리액트는 Virtual DOM(가상 돔)을 만들어서 이전 Virtual DOM 트리랑 비교(Diffing)하여 바뀐 부분을 실제 DOM에 반영(Reconciliation)한다.
- 그렇다면 렌더링이 일어날 때는 아래와 같다.
    - 상태가 바뀔 때 (useState로)
    - props가 바뀔 때, Context가 바뀔 때
    - 부모가 리랜더링되면서 자식도 덩달아 부모 컴포넌트가 바뀌면 자식들도 “어? 나도 바뀌어야 하나?” 하면서 리랜더링 (이게 중요)
    - …
- 여기에서 중요한 점은 나는 부모만 바꾸고 싶은데 자식까지 같이 바뀌어서 개발자가 가늠하지 못한 리랜더링이 일어난다는 것이다.
- 만약 자식 컴포넌트가 무거운 계산을 가지고 있다면, 부모가 바뀔 때마다 (말이 조금 이상하지만) 다시 계산을 해 주어야 하니 난감한 상황이 발생한다.
- 그럴 때 무거운 계산을 수행해야 하는 컴포넌트에게 useMemo, useCallback, React.memo 등으로 복잡한 계산을 캐싱해 준다.
    - `useMemo`: 복잡한 계산이 끝난 뒤 ‘값’을 메모이제이션한다.
    - `useCallback`: 함수 자체를 메모이제이션해서 불필요한 함수 재생성을 방지.
    - `React.memo`: 컴포넌트 자체를 메모이제이션한다.
- 이러한 메모이제이션 훅을 이용해서 이전 값과 현재 값이 같으면 리랜더링하지 않는다. 하지만 메모이제이션도 비용이므로 꼭 필요한 곳에만 사용한다.

### 메모이제이션에 대한 나의 생각을 적어주세요.

<!-- 예시

- 메모이제이션이 언제 필요할까?
- 메모이제이션을 사용하지 않으면 어떤 문제가 발생할까?
- 메모이제이션을 사용했을 때의 장점과 단점은 무엇일까?
- 메모이제이션을 사용하지 않고도 해결할 수 있는 방법은 무엇일까?
-->
- 그렇다면 메모이제이션은 언제 필요할까? 우선 메모이제이션이 무엇일까?
    - `메모이제이션`: 한 번 계산한 건 메모해 뒀다가(RAM(메모리)에 저장해 두었다가) 똑같은 계산을 해야 한다면, 메모리에 저장해 둔 걸 다시 재사용하는 것.
- 말만 들으면 오?! 이러면 죄다 저장하면 개꿀이잖아 ㅋㅋ 하겠지만.. 램은 한정되어 있고, 컴퓨터에 있는 램이 온전히 개발할 때 사용할 수도 없어서 너무 많이 저장하면 메모리 부족으로 컴퓨터가 느려진다.
- 즉, 메모이제이션은 꼭 필요한 때에 사용하라고 한다. 그러라고 하지만 아직까지 나는 메모이제이션을 어떻게 잘 사용해야 할지 감이 안 잡힌다. AI에게 물어봐도 10000을 반복문으로 돌렸을 때… 라는 예시만 줄 뿐이다.

### 컨텍스트와 상태관리에 대한 나의 생각을 적어주세요.

<!-- 예시

- 컨텍스트와 상태관리가 필요한 이유는 무엇일까?
- 컨텍스트와 상태관리를 사용하지 않으면 어떤 문제가 발생할까?
- 컨텍스트와 상태관리를 사용했을 때의 장점과 단점은 무엇일까?
- 컨텍스트와 상태관리를 사용하지 않고도 해결할 수 있는 방법은 무엇일까?
- 컨텍스트와 상태관리를 사용할 때 주의해야 할 점은 무엇일까?
-->
- 컨텍스트는 또 뭘까? 개발하다 보면 컨텍스트, 컨텍스트 한다. ~~한국인이면 모국어를 써라.~~
    - `컨텍스트`: 지금 어떤 상황인지, 어떤 환경인지 나타내는 정보. 리액트에서는 대다수의 컴포넌트에서 필요로 하는 값을 저장하는 저장소. (정확한가?!)
- 그러면 컨텍스트와 상태 관리는 같은 말일까?
    - `아니다!` 리액트에서 컨텍스트는 도구 같은 개념이고, 상태 관리는 목적? 개념적으로 더 큰 의미를 가진다. 즉 컨텍스트는 상태 관리 도구, 상태 관리는 방법론이다.
- 컨텍스트와 상태 관리는 왜 필요할끼?
    - props drilling을 방지하기 위해서다. A 컴포넌트에서 버튼을 누르면 전혀 다른 부모를 가진 B 컴포넌트에서 리랜더링이 일어나야 하는데, props로 옮겨 주려면 A 컴포넌트 자식으로 B가 있어야 하는데.. 애초에 말이 안 된다.
- 주의해야 할 점은, Context Provider로 감싼 컴포넌트들은 Context의 상태가 변경될 때 리랜더링 된다는 것이다. 그래서 dark / light 모드처럼 정말 모든 컴포넌트에 영향이 가야 하는 케이스일 때만 Context를 사용해 주는 게 좋을 것 같다.

## 리뷰 받고 싶은 내용

<!--
피드백 받고 싶은 내용을 구체적으로 남겨주세요
모호한 요청은 피드백을 남기기 어렵습니다.

참고링크: https://chatgpt.com/share/675b6129-515c-8001-ba72-39d0fa4c7b62

모호한 질문의 예시)

- 무엇을 질문해야 할지 몰라서 코치님이 보시기에 고쳐야할것들 전반적으로 피드백 부탁드립니다.
- 코드 스타일에 대한 피드백 부탁드립니다.
- 코드 구조에 대한 피드백 부탁드립니다.
- 개념적인 오류에 대한 피드백 부탁드립니다.
- 추가 구현이 필요한 부분에 대한 피드백 부탁드립니다.

구체적인 질문의 예시)

- 파일A의 함수B와 그 안의 변수명을 보면 직관성이 떨어지는 것 같습니다. 함수와 변수 이름을 더 명확하게 지을 방법에 대해 조언해 주실 수 있나요?
- 현재 파일 단위로 코드를 분리했지만, 이번 주차 발제를 기준으로 봤을 때 모듈화나 계층화에서 부족함이 있는 것 같습니다. 특히 A와 B 부분에서 모듈화를 더 진행할지 그대로 둘지 고민하였습니다. (...구체적인 고민 사항 적기...). 코치님의 의견이 궁금합니다.
- 옵저버 패턴을 사용해 상태 관리 로직을 구현해 보려 했습니다. 제가 구현한 코드가 옵저버 패턴에 맞게 잘 구성되었는지 검토해 주시고, 보완할 부분을 제안해 주실 수 있을까요?
- 컴포넌트 A를 테스트 할 때 B와의 의존성 때문에 테스트 코드를 작성하려다 포기했습니다. A와 B의 의존성을 낮추고 테스트 가능성을 높이는 구조 개선 방안이 있을까요?

과제에서 디테일한 피드백을 받기 위해선 여러분의 생각을 디테일하게 표현해주셔야 한답니다.

가령, "전반적으로 이 라우터 구조가 규모가 커졌을 때 유지보수나 기능 확장에 유리한지, 아니면 리팩토링이 필요할지 조언을 받고 싶습니다" 라는 질문이 있을 때, 답변드리기가 어려워요.
이럴 때는 "기능 확장" 상황을 먼저 가정해봐야합니다. 테스트의 엣지케이스를 작성하는 것 처럼요! 그리고 그 상황에 대해 내가 작성한 코드가 이러저러한 이유 때문에 대응가능할 것 같은데 혹시 더 고려해야할 부분이 있을지를 물어보는거죠.

이건 코치에게 이야기할 때 뿐만 아니라 팀원에게 이야기할 때에도 동일해요. 여러분의 컨텍스트를 명확하게 전달하지 않으면 여러분과 이야기할 때 시간이 무척 오래 걸린답니다.

특히 멘토링 처럼 동기적으로 이루어지는 커뮤니케이션에서는 위와 같은 질문을 던져도, 상호 피드백으로 질문을 함께 만들어갈 수 있지만, 과제 피드백 처럼 비동기 방식 + 1회용 질문일 때에는 좋은 답변을 드리기가 어려운점 인지 부탁드립니다 ㅠㅠ
-->

- useMemo, useCallback, React.memo의 구체적인? 실무적인? 예시를 모르겠습니다. 단순한 CRUD를 주로 만져서 그런지 메모이제이션을 쓸 일이 많이 없었는데요, 코치님께서는 작업을 하시다가 메모이제이션을 써야겠다! 라는 감이 올 때가 있으신가요?