### PR TITLE
[6팀 이민재] Chapter 1-3. React, Beyond the Basics 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,4 +35,4 @@ jobs:
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: ./packages/app/dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
           node-version: "22"
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 10
 
       - name: Install dependencies
         run: pnpm install
@@ -31,7 +31,7 @@ jobs:
           NODE_ENV: production
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+        env:
+          NODE_ENV: production
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/packages/app/src/components/toast/ToastProvider.tsx
+++ b/packages/app/src/components/toast/ToastProvider.tsx
@@ -8,26 +8,32 @@ import { debounce } from "../../utils";
 type ShowToast = (message: string, type: ToastType) => void;
 type Hide = () => void;
 
-const ToastContext = createContext<{
-  message: string;
-  type: ToastType;
+const ToastCommandContext = createContext<{
   show: ShowToast;
   hide: Hide;
 }>({
-  ...initialState,
   show: () => null,
   hide: () => null,
 });
 
+const ToastStateContext = createContext<{
+  message: string;
+  type: ToastType;
+}>({
+  ...initialState,
+});
+
 const DEFAULT_DELAY = 3000;
 
-const useToastContext = () => useContext(ToastContext);
+const useToastCommandContext = () => useContext(ToastCommandContext);
+const useToastStateContexts = () => useContext(ToastStateContext);
+
 export const useToastCommand = () => {
-  const { show, hide } = useToastContext();
+  const { show, hide } = useToastCommandContext();
   return { show, hide };
 };
 export const useToastState = () => {
-  const { message, type } = useToastContext();
+  const { message, type } = useToastStateContexts();
   return { message, type };
 };
 
@@ -44,9 +50,11 @@ export const ToastProvider = memo(({ children }: PropsWithChildren) => {
   };
 
   return (
-    <ToastContext value={{ show: showWithHide, hide, ...state }}>
-      {children}
-      {visible && createPortal(<Toast />, document.body)}
-    </ToastContext>
+    <ToastCommandContext.Provider value={{ show: showWithHide, hide }}>
+      <ToastStateContext.Provider value={{ message: state.message, type: state.type }}>
+        {children}
+        {visible && createPortal(<Toast />, document.body)}
+      </ToastStateContext.Provider>
+    </ToastCommandContext.Provider>
   );
 });

--- a/packages/app/src/components/toast/ToastProvider.tsx
+++ b/packages/app/src/components/toast/ToastProvider.tsx
@@ -44,9 +44,7 @@ export const ToastProvider = memo(({ children }: PropsWithChildren) => {
   const { show, hide } = useMemo(() => createActions(dispatch), [dispatch]);
   const visible = state.message !== "";
 
-  const hideAfter = useMemo(() => {
-    debounce(hide, DEFAULT_DELAY);
-  }, [hide]);
+  const hideAfter = useMemo(() => debounce(hide, DEFAULT_DELAY), [hide]);
 
   const showWithHide = useAutoCallback((message: string, type: ToastType) => {
     show(message, type);

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -8,9 +8,9 @@ export const createObserver = () => {
     listeners.add(fn);
   };
 
-  const unsubscribe = (fn: Listener) => {
-    listeners.delete(fn);
-  };
+  // const unsubscribe = (fn: Listener) => {
+  //   listeners.delete(fn);
+  // };
 
   const notify = () => listeners.forEach((listener) => listener());
 

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -6,11 +6,11 @@ export const createObserver = () => {
   // useSyncExternalStore 에서 활용할 수 있도록 subscribe 함수를 수정합니다.
   const subscribe = (fn: Listener) => {
     listeners.add(fn);
-  };
 
-  // const unsubscribe = (fn: Listener) => {
-  //   listeners.delete(fn);
-  // };
+    return (fn: Listener) => {
+      listeners.delete(fn);
+    };
+  };
 
   const notify = () => listeners.forEach((listener) => listener());
 

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -5,19 +5,21 @@ export const deepEquals = (a: unknown, b: unknown): boolean => {
 
   // 배열인 경우 재귀 비교
   if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
     for (let i = 0; i < a.length; i++) {
       if (!deepEquals(a[i], b[i])) return false;
     }
     return true;
   }
 
-  // 순수 객체 재귀 비교
-  const isObject = (val: unknown): val is Record<string, unknown> => {
-    return typeof val === "object" && val !== null && !Array.isArray(val);
-  };
+  const isObject = (val: unknown): val is Record<string, unknown> =>
+    typeof val === "object" && val !== null && !Array.isArray(val);
 
+  // 순수 객체 재귀 비교
   if (isObject(a) && isObject(b)) {
     const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+    if (keysA.length !== keysB.length) return false;
 
     for (const key of keysA) {
       if (!Object.prototype.hasOwnProperty.call(b, key)) return false;

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,3 +1,42 @@
-export const deepEquals = (a: unknown, b: unknown) => {
-  return a === b;
+export const deepEquals = (a: unknown, b: unknown): boolean => {
+  // 1. 기본 값 비교
+  if (a === b || (Number.isNaN(a) && Number.isNaN(b))) return true;
+
+  // 2. 배열 비교
+  if (Array.isArray(a) && Array.isArray(b)) {
+    // 배열의 length로 비교
+    if (a.length !== b.length) return false;
+
+    // 재귀적으로 모든 depth의 요소를 비교
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEquals(a[i], b[i])) return false;
+    }
+
+    return true;
+  }
+
+  // 배열이 아닌데 한쪽만 배열이면 false
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+  // 3. 순수 객체 비교
+  const isObject = (val: unknown): val is Record<string, unknown> => {
+    return typeof val === "object" && val !== null && !Array.isArray(val);
+  };
+
+  if (isObject(a) && isObject(b)) {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+
+    if (keysA.length !== keysB.length) return false;
+
+    for (const key of keysA) {
+      if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+      if (!deepEquals(a[key], b[key])) return false;
+    }
+
+    return true;
+  }
+
+  // 기본 타입인데 === 실패했으면 false
+  return false;
 };

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,33 +1,23 @@
+import { shallowEquals } from "./shallowEquals";
+
 export const deepEquals = (a: unknown, b: unknown): boolean => {
-  // 1. 기본 값 비교
-  if (a === b || (Number.isNaN(a) && Number.isNaN(b))) return true;
+  if (shallowEquals(a, b)) return true;
 
-  // 2. 배열 비교
+  // 배열인 경우 재귀 비교
   if (Array.isArray(a) && Array.isArray(b)) {
-    // 배열의 length로 비교
-    if (a.length !== b.length) return false;
-
-    // 재귀적으로 모든 depth의 요소를 비교
     for (let i = 0; i < a.length; i++) {
       if (!deepEquals(a[i], b[i])) return false;
     }
-
     return true;
   }
 
-  // 배열이 아닌데 한쪽만 배열이면 false
-  if (Array.isArray(a) !== Array.isArray(b)) return false;
-
-  // 3. 순수 객체 비교
+  // 순수 객체 재귀 비교
   const isObject = (val: unknown): val is Record<string, unknown> => {
     return typeof val === "object" && val !== null && !Array.isArray(val);
   };
 
   if (isObject(a) && isObject(b)) {
     const keysA = Object.keys(a);
-    const keysB = Object.keys(b);
-
-    if (keysA.length !== keysB.length) return false;
 
     for (const key of keysA) {
       if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
@@ -37,6 +27,5 @@ export const deepEquals = (a: unknown, b: unknown): boolean => {
     return true;
   }
 
-  // 기본 타입인데 === 실패했으면 false
   return false;
 };

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,3 +1,42 @@
-export const shallowEquals = (a: unknown, b: unknown) => {
-  return a === b;
+export const shallowEquals = (a: unknown, b: unknown): boolean => {
+  // 1. 기본 타입 값들을 정확히 비교해야 한다.
+  if (a === b || (Number.isNaN(a) && Number.isNaN(b))) return true;
+
+  // 2. 배열을 얇게 비교해야 한다.
+  if (Array.isArray(a) && Array.isArray(b)) {
+    // 배열의 length로 비교
+    if (a.length !== b.length) return false;
+
+    // 배열의 1depth 요소를 비교
+    for (let i = 0; i < a.length; i++) {
+      if (a[i] !== b[i]) return false;
+    }
+
+    return true;
+  }
+
+  // 배열이 아닌데 한쪽만 배열이면 false
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+
+  // 3. 순수 객체 비교
+  const isObject = (val: unknown): val is Record<string, unknown> => {
+    return typeof val === "object" && val !== null && !Array.isArray(val);
+  };
+
+  if (isObject(a) && isObject(b)) {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+
+    if (keysA.length !== keysB.length) return false;
+
+    for (const key of keysA) {
+      if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
+      if (a[key] !== b[key]) return false; // 얕은 비교
+    }
+
+    return true;
+  }
+
+  // 기본값인데 === 실패했으면 false
+  return false;
 };

--- a/packages/lib/src/hocs/deepMemo.ts
+++ b/packages/lib/src/hocs/deepMemo.ts
@@ -1,5 +1,11 @@
 import type { FunctionComponent } from "react";
+import { memo } from "./memo";
+import { deepEquals } from "../equals";
 
+// deepMemo HOC는 컴포넌트의 props를 깊은 비교하여 불필요한 리렌더링을 방지합니다.
 export function deepMemo<P extends object>(Component: FunctionComponent<P>) {
-  return Component;
+  // deepEquals 함수를 사용하여 props 비교
+  // 앞에서 만든 memo를 사용
+
+  return memo(Component, deepEquals);
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -1,6 +1,7 @@
 import { type FunctionComponent } from "react";
-import { shallowEquals } from "../equals";
+// import { shallowEquals } from "../equals";
 
-export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
+// export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
+export function memo<P extends object>(Component: FunctionComponent<P>) {
   return Component;
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -1,7 +1,32 @@
-import { type FunctionComponent } from "react";
-// import { shallowEquals } from "../equals";
+import { type FunctionComponent, useRef } from "react";
+import { shallowEquals } from "../equals";
 
-// export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
-export function memo<P extends object>(Component: FunctionComponent<P>) {
-  return Component;
+// memo HOC는 컴포넌트의 props를 얕은 비교하여 불필요한 렌더링을 방지합니다.
+export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals): FunctionComponent<P> {
+  // 메모이제이션된 컴포넌트 생성
+  const MemoizedComponent: FunctionComponent<P> = (props) => {
+    // 1. 이전 props를 저장할 ref 생성
+    const memoizedRef = useRef<{
+      prevProps: P | null;
+      rendered: ReturnType<FunctionComponent<P>> | null;
+    }>({
+      // 이전 props 저장
+      prevProps: null,
+      // 이전 JSX 저장
+      rendered: null,
+    });
+
+    // 3. eqauls 함수를 사용하여 props 비교 - 새롭게 컴포넌트 렌더링X
+    if (memoizedRef.current.prevProps !== null && equals(memoizedRef.current.prevProps, props)) {
+      return memoizedRef.current.rendered!;
+    }
+
+    // 4. props가 변경된 경우에만 새로운 렌더링 수행
+    memoizedRef.current.prevProps = props;
+    memoizedRef.current.rendered = Component(props);
+
+    return memoizedRef.current.rendered;
+  };
+
+  return MemoizedComponent;
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -1,5 +1,6 @@
-import { type FunctionComponent, useRef } from "react";
+import { type FunctionComponent } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "../hooks";
 
 // memo HOC는 컴포넌트의 props를 얕은 비교하여 불필요한 렌더링을 방지합니다.
 export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals): FunctionComponent<P> {

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -1,6 +1,6 @@
 import type { AnyFunction } from "../types";
-import { useCallback } from "./useCallback";
-import { useRef } from "./useRef";
+// import { useCallback } from "./useCallback";
+// import { useRef } from "./useRef";
 
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
   return fn;

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -1,7 +1,17 @@
 import type { AnyFunction } from "../types";
-// import { useCallback } from "./useCallback";
-// import { useRef } from "./useRef";
+import { useCallback } from "./useCallback";
+import { useRef } from "./useRef";
 
+// useCallback과 useRef를 이용하여 useAutoCallback
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
-  return fn;
+  // 1. 콜백함수가 참조하는 값은 항상 렌더링 시점에 최신화 되어야 한다.
+  const callbackFnRef = useRef(fn);
+  callbackFnRef.current = fn;
+
+  // 2. 대신 항상 동일한 참조를 유지해야 한다. (useCallback 활용)
+  const stableFn = useCallback((...args: unknown[]) => {
+    return callbackFnRef.current(...args);
+  }, []);
+
+  return stableFn as T;
 };

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
-import type { DependencyList } from "react";
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
+import { useMemo, type DependencyList } from "react";
 
 export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
   // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  return useMemo(() => factory, _deps);
 }

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-function-type */
-import { useMemo, type DependencyList } from "react";
+import { type DependencyList } from "react";
+import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
   // 직접 작성한 useMemo를 통해서 만들어보세요.

--- a/packages/lib/src/hooks/useDeepMemo.ts
+++ b/packages/lib/src/hooks/useDeepMemo.ts
@@ -4,6 +4,5 @@ import { useMemo } from "./useMemo";
 import { deepEquals } from "../equals";
 
 export function useDeepMemo<T>(factory: () => T, deps: DependencyList): T {
-  // 직접 작성한 useMemo를 참고해서 만들어보세요.
   return useMemo(factory, deps, deepEquals);
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -1,8 +1,24 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import type { DependencyList } from "react";
+import { useRef, type DependencyList } from "react";
 import { shallowEquals } from "../equals";
 
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
   // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+  // 1. 이전 의존성과 결과를 저장할 ref 생성
+  const ref = useRef<{ value: T; deps: DependencyList } | null>(null);
+
+  // 2. 현재 의존성과 이전 의존성 비교
+  const currentDeps = _deps;
+  const prevDeps = ref.current?.deps;
+  const isSameDeps = prevDeps && _equals(currentDeps, prevDeps);
+
+  // 3. 의존성이 변경된 경우 factory 함수 실행 및 결과 저장
+  if (!isSameDeps || !ref.current) {
+    ref.current = {
+      value: factory(),
+      deps: _deps,
+    };
+  }
+
+  // 4. 메모이제이션된 값 반환
+  return ref.current.value;
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -1,5 +1,6 @@
-import { useRef, type DependencyList } from "react";
+import { type DependencyList } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "./useRef";
 
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
   // 직접 작성한 useRef를 통해서 만들어보세요.

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,4 +1,7 @@
+import { useState } from "react";
+
 export function useRef<T>(initialValue: T): { current: T } {
-  // useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  const [state] = useState(<{ current: T }>{ current: initialValue });
+
+  return state;
 }

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -1,6 +1,6 @@
 import type { RouterInstance } from "../Router";
 import type { AnyFunction } from "../types";
-import { useSyncExternalStore } from "react";
+// import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
 
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -1,12 +1,15 @@
 import type { RouterInstance } from "../Router";
 import type { AnyFunction } from "../types";
-// import { useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
 
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 
 export const useRouter = <T extends RouterInstance<AnyFunction>, S>(router: T, selector = defaultSelector<T, S>) => {
-  // useSyncExternalStore를 사용하여 router의 상태를 구독하고 가져오는 훅을 구현합니다.
+  // useSyncExternalStore를 사용하여 router의 상태를 구독하고,
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(router);
+  // 가져오는 훅을 구현합니다.
+  const getSnapShot = () => shallowSelector(router);
+
+  return useSyncExternalStore(router.subscribe, getSnapShot);
 };

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -1,5 +1,5 @@
-import { useRef } from "react";
-import { shallowEquals } from "../equals";
+// import { useRef } from "react";
+// import { shallowEquals } from "../equals";
 
 type Selector<T, S = T> = (state: T) => S;
 

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -1,9 +1,19 @@
-// import { useRef } from "react";
-// import { shallowEquals } from "../equals";
+import { useRef } from "react";
+import { shallowEquals } from "../equals";
 
 type Selector<T, S = T> = (state: T) => S;
 
 export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
-  // 이전 상태를 저장하고, shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
-  return (state: T): S => selector(state);
+  const prevSelectedRef = useRef<S | null>(null);
+  return (state: T): S => {
+    // 이전 상태를 저장하고
+    const selected = selector(state);
+    // shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
+    if (prevSelectedRef.current !== null && shallowEquals(prevSelectedRef.current, selected)) {
+      return prevSelectedRef.current;
+    }
+
+    prevSelectedRef.current = selected;
+    return selected;
+  };
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,8 +1,22 @@
-import { useState } from "react";
-// import { shallowEquals } from "../equals";
+import { useState, useCallback } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { shallowEquals } from "../equals";
 
-// export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
-export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>) => {
-  // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
-  return useState(initialValue);
+// shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
+function resolveNextState<T>(prevState: T, newValue: SetStateAction<T>): T {
+  // 함수형 업데이트인 경우 예외처리
+  const nextState = typeof newValue === "function" ? (newValue as (prevState: T) => T)(prevState) : newValue;
+
+  return shallowEquals(prevState, nextState) ? prevState : nextState;
+}
+
+export const useShallowState = <T>(initialValue: T | (() => T)): [T, Dispatch<SetStateAction<T>>] => {
+  // useState를 사용하여 상태를 관리하고,
+  const [state, setState] = useState<T>(initialValue);
+
+  const setShallowState = useCallback<Dispatch<SetStateAction<T>>>((newValue) => {
+    setState((prevState) => resolveNextState(prevState, newValue));
+  }, []);
+
+  return [state, setShallowState];
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { shallowEquals } from "../equals";
+// import { shallowEquals } from "../equals";
 
-export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
+// export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
+export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>) => {
   // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
   return useState(initialValue);
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,6 +1,7 @@
-import { useState, useCallback } from "react";
+import { useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { shallowEquals } from "../equals";
+import { useCallback } from "./useCallback";
 
 // shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
 function resolveNextState<T>(prevState: T, newValue: SetStateAction<T>): T {

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+// import { useSyncExternalStore } from "react";
 import type { createStorage } from "../createStorage";
 
 type Storage<T> = ReturnType<typeof createStorage<T>>;

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -1,9 +1,9 @@
-// import { useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import type { createStorage } from "../createStorage";
 
 type Storage<T> = ReturnType<typeof createStorage<T>>;
 
 export const useStorage = <T>(storage: Storage<T>) => {
   // useSyncExternalStore를 사용해서 storage의 상태를 구독하고 가져오는 훅을 구현해보세요.
-  return storage.get();
+  return useSyncExternalStore(storage.subscribe, storage.get);
 };

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -1,5 +1,5 @@
 import type { createStore } from "../createStore";
-import { useSyncExternalStore } from "react";
+// import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
 
 type Store<T> = ReturnType<typeof createStore<T>>;

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -1,5 +1,5 @@
 import type { createStore } from "../createStore";
-// import { useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
 
 type Store<T> = ReturnType<typeof createStore<T>>;
@@ -7,7 +7,11 @@ type Store<T> = ReturnType<typeof createStore<T>>;
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 
 export const useStore = <T, S = T>(store: Store<T>, selector: (state: T) => S = defaultSelector<T, S>) => {
-  // useSyncExternalStore와 useShallowSelector를 사용해서 store의 상태를 구독하고 가져오는 훅을 구현해보세요.
+  // useSyncExternalStore와 useShallowSelector를 사용해서 store의 상태를 구독하고
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(store.getState());
+
+  // 가져오는 훅을 구현해보세요.
+  const getSnapShot = () => shallowSelector(store.getState());
+
+  return useSyncExternalStore(store.subscribe, getSnapShot);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 8.36.0(eslint@9.30.1)(typescript@5.8.3)
       vite:
         specifier: npm:rolldown-vite@latest
-        version: rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0)
+        version: rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0)
       vitest:
         specifier: latest
         version: 3.2.4(@types/node@24.0.13)(@vitest/ui@3.2.4)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.3(@types/node@24.0.13)(typescript@5.8.3))(yaml@2.8.0)
@@ -110,7 +110,7 @@ importers:
         version: 1.5.0
       '@vitejs/plugin-react-oxc':
         specifier: latest
-        version: 0.2.3(rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0))
+        version: 0.3.0(rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0))
       eslint:
         specifier: ^9.9.0
         version: 9.30.1
@@ -137,7 +137,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: npm:rolldown-vite@latest
-        version: rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0)
+        version: rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0)
 
   packages/lib:
     dependencies:
@@ -183,10 +183,10 @@ importers:
         version: 1.5.0
       '@vitejs/plugin-react-oxc':
         specifier: latest
-        version: 0.2.3(rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0))
+        version: 0.3.0(rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0))
       '@vitejs/plugin-react-swc':
         specifier: latest
-        version: 3.10.2(rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0))
+        version: 3.11.0(rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0))
       eslint:
         specifier: ^9.9.0
         version: 9.30.1
@@ -210,7 +210,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: npm:rolldown-vite@latest
-        version: rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0)
+        version: rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0)
       vitest:
         specifier: latest
         version: 3.2.4(@types/node@24.0.13)(@vitest/ui@3.2.4)(jsdom@26.1.0)(lightningcss@1.30.1)(msw@2.10.3(@types/node@24.0.13)(typescript@5.8.3))(yaml@2.8.0)
@@ -359,14 +359,14 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@emnapi/core@1.4.4':
-    resolution: {integrity: sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==}
+  '@emnapi/core@1.4.5':
+    resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
 
-  '@emnapi/runtime@1.4.4':
-    resolution: {integrity: sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg==}
+  '@emnapi/runtime@1.4.5':
+    resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
 
-  '@emnapi/wasi-threads@1.0.3':
-    resolution: {integrity: sha512-8K5IFFsQqF9wQNJptGbS6FNKgUTsSRYnTqNCG1vPP8jFdjSv18n2mQfJpkt2Oibo9iBEzcDnDxNwKTzC7svlJw==}
+  '@emnapi/wasi-threads@1.0.4':
+    resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
 
   '@esbuild/aix-ppc64@0.24.2':
     resolution: {integrity: sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==}
@@ -636,8 +636,8 @@ packages:
     resolution: {integrity: sha512-RuzCup9Ct91Y7V79xwCb146RaBRHZ7NBbrIUySumd1rpKqHL5OonaqrGIbug5hNwP/fRyxFMA6ISgw4FTtYFYg==}
     engines: {node: '>=18'}
 
-  '@napi-rs/wasm-runtime@0.2.12':
-    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+  '@napi-rs/wasm-runtime@1.0.1':
+    resolution: {integrity: sha512-KVlQ/jgywZpixGCKMNwxStmmbYEMyokZpCf2YuIChhfJA2uqfAKNEM8INz7zzTo55iEXfBhIIs3VqYyqzDLj8g==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -660,12 +660,12 @@ packages:
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
-  '@oxc-project/runtime@0.77.0':
-    resolution: {integrity: sha512-cMbHs/DaomWSjxeJ79G10GA5hzJW9A7CZ+/cO+KuPZ7Trf3Rr07qSLauC4Ns8ba4DKVDjd8VSC9nVLpw6jpoGQ==}
+  '@oxc-project/runtime@0.77.3':
+    resolution: {integrity: sha512-vsC/ewcGJ7xXnnwZkku7rpPH5Lxb5g4J+V6lD9eBTnRLmXVXM7Qu50y+ozD+UD5IXaSoVOvVMGTT4YSNCz2MQQ==}
     engines: {node: '>=6.9.0'}
 
-  '@oxc-project/types@0.77.0':
-    resolution: {integrity: sha512-iUQj185VvCPnSba+ltUV5tVDrPX6LeZVtQywnnoGbe4oJ1VKvDKisjGkD/AvVtdm98b/BdsVS35IlJV1m2mBBA==}
+  '@oxc-project/types@0.77.3':
+    resolution: {integrity: sha512-5Vh+neJhhxuF0lYCjZXbxjqm2EO6YJ1jG+KuHntrd6VY67OMpYhWq2cZhUhy+xL9qLJVJRaeII7Xj9fciA6v7A==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -683,81 +683,81 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.27':
-    resolution: {integrity: sha512-IJL3efUJmvb5MfTEi7bGK4jq3ZFAzVbSy+vmul0DcdrglUd81Tfyy7Zzq2oM0tUgmACG32d8Jz/ykbpbf+3C5A==}
+  '@rolldown/binding-android-arm64@1.0.0-beta.29':
+    resolution: {integrity: sha512-pDv7gg59Gdy80eFmMkEqXEaoJi3Y9W/a9T3z9M4t8Ma8aVXNldvSy9UgtlX7AK7DPqF8tULnmIZ2Z3rvGMz/NQ==}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.27':
-    resolution: {integrity: sha512-TXTiuHbtnHfb0c44vNfWfIyEFJ0BFUf63ip9Z4mj8T2zRcZXQYVger4OuAxnwGNGBgDyHo1VaNBG+Vxn2VrpqQ==}
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.29':
+    resolution: {integrity: sha512-fPqR6TfTqbzgKKCQYtcCS+Dms91YcptTbdlwJ13DxOUgMe8LgDIVsLLlEykfm7ijJd5mM4zNw0Hr2CJb6kvQZw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.27':
-    resolution: {integrity: sha512-Jpjflgvbolh+fAaaEajPJQCOpZMawYMbNVzuZp3nidX1B7kMAP7NEKp9CWzthoL2Y8RfD7OApN6bx4+vFurTaw==}
+  '@rolldown/binding-darwin-x64@1.0.0-beta.29':
+    resolution: {integrity: sha512-7Z4qosL0xN8i6++txHOEPCVP3/lcGLOvftUJOWATZ5aDkDskwcZDa66BGiJt/K1/DgW4kpRVmnGWUWAORHBbFA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.27':
-    resolution: {integrity: sha512-07ZNlXIunyS1jCTnene7aokkzCZNBUnmnJWu4Nz5X5XQvVHJNjsDhPFJTlNmneSDzA3vGkRNwdECKXiDTH/CqA==}
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.29':
+    resolution: {integrity: sha512-0HLTfPW5Glh608s76qgayN/nPsXPchNUumavf7W5nh1eMG6qBsOO7Q1QaK0v4un7qtsn3IA/1Tgq0ZgNc0dbeg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.27':
-    resolution: {integrity: sha512-z74ah00oyKnTUtaIbg34TaIU1PYM8tGE1bK6aUs8OLZ9sWW4g3Xo5A0nit2zyeanmYFvrAUxnt3Bpk+mTZCtlg==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.29':
+    resolution: {integrity: sha512-QNboxdVTJOZS4zP8kA2+XUwAegejd5QNSH5zVR4neqG2AfbxRcMFzSVRkJHN6yDaaKweD/4sUvXfmef6p/7zsw==}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.27':
-    resolution: {integrity: sha512-b9oKl/M5OIyAcosS73BmjOZOjvcONV97t2SnKpgwfDX/mjQO3dBgTYyvHMFA6hfhIDW1+2XVQR/k5uzBULFhoA==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.29':
+    resolution: {integrity: sha512-hzBmOtYdC4369XxN2SNJ3oBlXKWNif3ieWBT+oh/qvAeox4fQR0ngqyh+kIGOufBnP5Zc2rqJf9LzIbJw3Tx/Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.27':
-    resolution: {integrity: sha512-RmaNSkVmAH8u/r5Q+v4O0zL4HY8pLrvlM5wBoBrb/QHDQgksGKBqhecpg1ERER0Q7gMh/GJUz6JiiD55Q+9UOA==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.29':
+    resolution: {integrity: sha512-6B35GmFJJ4RX88OgubrnUmuJBUgRh6/OTXIpy8m/VUnoc683lufIPo26HW/0LxLgxp2GM7KHr3LOULcVxbqq4Q==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.27':
-    resolution: {integrity: sha512-gq78fI/g0cp1UKFMk53kP/oZAgYOXbaqdadVMuCJc0CoSkDJcpO2YIasRs/QYlE91QWfcHD5RZl9zbf4ksTS/w==}
+  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.29':
+    resolution: {integrity: sha512-z3ru8fUCunQM8q9I7RbDVMT5cxzxVVVBNNKM5/qAQQrdObd1u8g0LR5z0yLtaFWzybwLVdPtJDRcXtLm5tOBFA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.27':
-    resolution: {integrity: sha512-yS/GreJ6BT44dHu1WLigc50S8jZA+pDzzsf8tqRptUTwi5YW7dX3NqcDlc/lXsZqu57aKynLljgClYAm90LEKw==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.29':
+    resolution: {integrity: sha512-n6fs4L7j99MIiI6vKhQDdyScv4/uMAPtIMkB0zGbUX8MKWT1osym1hvWVdlENjnS/Phf0zzhjyOgoFDzdhI1cQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.27':
-    resolution: {integrity: sha512-6FV9To1sXewGHY4NaCPeOE5p5o1qfuAjj+m75WVIPw9HEJVsQoC5QiTL5wWVNqSMch4X0eWnQ6WsQolU6sGMIA==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.29':
+    resolution: {integrity: sha512-C5hcJgtDN4rp6/WsPTQSDVUWrdnIC//ynMGcUIh1O0anm9KnSy47zKQ5D9EqtlEKvO+2PPqmyUVJ2DTq18nlVA==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.27':
-    resolution: {integrity: sha512-VcxdhF0PQda9krFJHw4DqUkdAsHWYs/Uz/Kr/zhU8zMFDzmK6OdUgl9emGj9wTzXAEHYkAMDhk+OJBRJvp424g==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.29':
+    resolution: {integrity: sha512-lMN1IBItdZFO182Sdus9oVuNDqyIymn/bsR5KwgeGaiqLsrmpQHBSLwkS/nKJO1nzYlpGDRugFSpnrSJ5ZmihQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.27':
-    resolution: {integrity: sha512-3bXSARqSf8jLHrQ1/tw9pX1GwIR9jA6OEsqTgdC0DdpoZ+34sbJXE9Nse3dQ0foGLKBkh4PqDv/rm2Thu9oVBw==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.29':
+    resolution: {integrity: sha512-0UrXCUAOrbWdyVJskzjtne/4d3YMMhhhpBnob3SeF4jAvbKYqPhCZJ71pP7yUpvbowGXXTnHWpKfitg4Sovmtw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.27':
-    resolution: {integrity: sha512-xPGcKb+W8NIWAf5KApsUIrhiKH5NImTarICge5jQ2m0BBxD31crio4OXy/eYVq5CZkqkqszLQz2fWZcWNmbzlQ==}
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.29':
+    resolution: {integrity: sha512-YX0OYL1dcB7rPnsndpEa68fytYyZZj1iaWzH7momFB2oBS2lXAe1UrrDWcdLoUXdzPIyzpvtBCiS2XcDgYG7ag==}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.27':
-    resolution: {integrity: sha512-3y1G8ARpXBAcz4RJM5nzMU6isS/gXZl8SuX8lS2piFOnQMiOp6ajeelnciD+EgG4ej793zvNvr+WZtdnao2yrw==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.29':
+    resolution: {integrity: sha512-azrPWbV+NZiCFNs59AgH9Y6vFKHoAI6T/XtKKsoLxkPyP1LpbdgL5eqRfeWz+GCAUY9qhDOC4hH1GjFG8PrZIg==}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.11':
-    resolution: {integrity: sha512-L/gAA/hyCSuzTF1ftlzUSI/IKr2POHsv1Dd78GfqkR83KMNuswWD61JxGV2L7nRwBBBSDr6R1gCkdTmoN7W4ag==}
-
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rolldown/pluginutils@1.0.0-beta.29':
+    resolution: {integrity: sha512-NIJgOsMjbxAXvoGq/X0gD7VPMQ8j9g0BiDaNjVNVjvl+iKXxL3Jre0v31RmBYeLEmkbj2s02v8vFTbUXi5XS2Q==}
 
   '@rollup/rollup-android-arm-eabi@4.44.2':
     resolution: {integrity: sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==}
@@ -1063,16 +1063,16 @@ packages:
     resolution: {integrity: sha512-vZrhV2lRPWDuGoxcmrzRZyxAggPL+qp3WzUrlZD+slFueDiYHxeBa34dUXPuC0RmGKzl4lS5kFJYvKCq9cnNDA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitejs/plugin-react-oxc@0.2.3':
-    resolution: {integrity: sha512-ONriHoEGQv+ITmeJQsHIpx7u1ms8Z68oIo3AdKCoaBTvZtF+AfDVviQ3tKgCTnIbz9NW8V2Rd/Q+5zjzpsht1g==}
+  '@vitejs/plugin-react-oxc@0.3.0':
+    resolution: {integrity: sha512-OaqaDIc74NNuqH1xKGbGoErpKP8L1XlxBQsfWvIUfpQaDCe5El9Ac5mPrvn/Dg0pv3xKB/PNm4Wirxr6hnKu/A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      vite: ^6.3.0 || ^7.0.0-beta.0
+      vite: ^6.3.0 || ^7.0.0
 
-  '@vitejs/plugin-react-swc@3.10.2':
-    resolution: {integrity: sha512-xD3Rdvrt5LgANug7WekBn1KhcvLn1H3jNBfJRL3reeOIua/WnZOEV5qi5qIBq5T8R0jUDmRtxuvk4bPhzGHDWw==}
+  '@vitejs/plugin-react-swc@3.11.0':
+    resolution: {integrity: sha512-YTJCGFdNMHCMfjODYtxRNVAYmTWQ1Lb8PulP/2/f/oEEtglw8oKxKIZmmRkyXrVrHfsKOaVkAc3NT9/dMutO5w==}
     peerDependencies:
-      vite: ^4 || ^5 || ^6 || ^7.0.0-beta.0
+      vite: ^4 || ^5 || ^6 || ^7
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -2139,8 +2139,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-  rolldown-vite@7.0.9:
-    resolution: {integrity: sha512-RxVP6CY9CNCEM9UecdytqeADxOGSjgkfSE/eI986sM7I3/F09lQ9UfQo3y6W10ICBppKsEHe71NbCX/tirYDFg==}
+  rolldown-vite@7.0.10:
+    resolution: {integrity: sha512-t3jMDID78NAJ2PWd0Q5RFrDpD1mFv20ouO/yDbqeHzG2Iyi2ZsjChLKClag1bUm591JJXBsoJIjP6FDkFi9qbw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2179,8 +2179,8 @@ packages:
       yaml:
         optional: true
 
-  rolldown@1.0.0-beta.27:
-    resolution: {integrity: sha512-aYiJmzKoUHoaaEZLRegYVfZkXW7gzdgSbq+u5cXQ6iXc/y8tnQ3zGffQo44Pr1lTKeLluw3bDIDUCx/NAzqKeA==}
+  rolldown@1.0.0-beta.29:
+    resolution: {integrity: sha512-EsoOi8moHN6CAYyTZipxDDVTJn0j2nBCWor4wRU45RQ8ER2qREDykXLr3Ulz6hBh6oBKCFTQIjo21i0FXNo/IA==}
     hasBin: true
 
   rollup@4.44.2:
@@ -2785,18 +2785,18 @@ snapshots:
   '@csstools/css-tokenizer@3.0.4':
     optional: true
 
-  '@emnapi/core@1.4.4':
+  '@emnapi/core@1.4.5':
     dependencies:
-      '@emnapi/wasi-threads': 1.0.3
+      '@emnapi/wasi-threads': 1.0.4
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.4.4':
+  '@emnapi/runtime@1.4.5':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.0.3':
+  '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2997,10 +2997,10 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
-  '@napi-rs/wasm-runtime@0.2.12':
+  '@napi-rs/wasm-runtime@1.0.1':
     dependencies:
-      '@emnapi/core': 1.4.4
-      '@emnapi/runtime': 1.4.4
+      '@emnapi/core': 1.4.5
+      '@emnapi/runtime': 1.4.5
       '@tybys/wasm-util': 0.10.0
     optional: true
 
@@ -3025,9 +3025,9 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@oxc-project/runtime@0.77.0': {}
+  '@oxc-project/runtime@0.77.3': {}
 
-  '@oxc-project/types@0.77.0': {}
+  '@oxc-project/types@0.77.3': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3040,53 +3040,53 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.27':
+  '@rolldown/binding-android-arm64@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.27':
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.27':
+  '@rolldown/binding-darwin-x64@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.27':
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.27':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.27':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.27':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.27':
+  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.27':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.27':
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.27':
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.29':
     dependencies:
-      '@napi-rs/wasm-runtime': 0.2.12
+      '@napi-rs/wasm-runtime': 1.0.1
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.27':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.27':
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.29':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.27':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.29':
     optional: true
-
-  '@rolldown/pluginutils@1.0.0-beta.11': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.29': {}
 
   '@rollup/rollup-android-arm-eabi@4.44.2':
     optional: true
@@ -3364,16 +3364,16 @@ snapshots:
       '@typescript-eslint/types': 8.36.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react-oxc@0.2.3(rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0))':
+  '@vitejs/plugin-react-oxc@0.3.0(rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0))':
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.11
-      vite: rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      vite: rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0)
 
-  '@vitejs/plugin-react-swc@3.10.2(rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0))':
+  '@vitejs/plugin-react-swc@3.11.0(rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0))':
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.11
+      '@rolldown/pluginutils': 1.0.0-beta.27
       '@swc/core': 1.12.14
-      vite: rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0)
+      vite: rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -4431,40 +4431,40 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-vite@7.0.9(@types/node@24.0.13)(yaml@2.8.0):
+  rolldown-vite@7.0.10(@types/node@24.0.13)(yaml@2.8.0):
     dependencies:
       fdir: 6.4.6(picomatch@4.0.2)
       lightningcss: 1.30.1
       picomatch: 4.0.2
       postcss: 8.5.6
-      rolldown: 1.0.0-beta.27
+      rolldown: 1.0.0-beta.29
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 24.0.13
       fsevents: 2.3.3
       yaml: 2.8.0
 
-  rolldown@1.0.0-beta.27:
+  rolldown@1.0.0-beta.29:
     dependencies:
-      '@oxc-project/runtime': 0.77.0
-      '@oxc-project/types': 0.77.0
-      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@oxc-project/runtime': 0.77.3
+      '@oxc-project/types': 0.77.3
+      '@rolldown/pluginutils': 1.0.0-beta.29
       ansis: 4.1.0
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-beta.27
-      '@rolldown/binding-darwin-arm64': 1.0.0-beta.27
-      '@rolldown/binding-darwin-x64': 1.0.0-beta.27
-      '@rolldown/binding-freebsd-x64': 1.0.0-beta.27
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.27
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.27
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.27
-      '@rolldown/binding-linux-arm64-ohos': 1.0.0-beta.27
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.27
-      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.27
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.27
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.27
-      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.27
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.27
+      '@rolldown/binding-android-arm64': 1.0.0-beta.29
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.29
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.29
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.29
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.29
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.29
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.29
+      '@rolldown/binding-linux-arm64-ohos': 1.0.0-beta.29
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.29
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.29
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.29
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.29
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.29
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.29
 
   rollup@4.44.2:
     dependencies:


### PR DESCRIPTION
## 과제 체크포인트
https://minjaeleee.github.io/front_6th_chapter1-3

### 배포 링크

<!--
배포 링크를 적어주세요
예시: https://<username>.github.io/front-6th-chapter1-3/

배포가 완료되지 않으면 과제를 통과할 수 없습니다.
배포 후에 정상 작동하는지 확인해주세요.
-->

### 기본과제

#### equalities

- [x] shallowEquals 구현 완료
- [x] deepEquals 구현 완료

#### hooks

- [x] useRef 구현 완료
- [x] useMemo 구현 완료
- [x] useCallback 구현 완료
- [x] useDeepMemo 구현 완료
- [x] useShallowState 구현 완료
- [x] useAutoCallback 구현 완료

#### High Order Components

- [x] memo 구현 완료
- [x] deepMemo 구현 완료

### 심화 과제

#### hooks

- [x] createObserver를 useSyncExternalStore에 사용하기 적합한 코드로 개선
- [x] useShallowSelector 구현
- [x] useStore 구현
- [x] useRouter 구현
- [x] useStorage 구현

### context

- [x] ToastContext, ModalContext 개선

## 과제 셀프회고

<!-- 과제에 대한 회고를 작성해주세요 -->

### 기술적 성장

평소 참조 동일성에 대해서 깊이 이해하지 않았습니다.(= 그동안 대충 아는 ‘척’만 하고 중요한 사실은 스윽 넘겼다…) 메모이제이션이나 hooks에서 사용하는 의존성 배열에 해당하는 값들은 항상 참조 동일성을 유지하게 되고 렌더링 부분에서 즉시 비용 감소로 여겼기 때문입니다.
사실 이 부분을 유심히 고민해보면 저는 리액트의 얕은 비교를 통한 렌더링 원리에 대해서 부족했던 것 같습니다. 따라서, 다시 이 부분을 따라가서 정리해보았습니다.

**참조 동일성이란?**

```jsx
function MyComponent() {
  const config = { darkMode: true };

  useEffect(() => {
    console.log("config changed!");
  }, [config]);

  return null;
}
```

- 이 컴포넌트가 리렌더링될 때마다 `config` 객체는 새로 만들어집니다.
- 값은 같아 보여도 참조가 다르기 때문에 useEffect는 매번 실행이 됩니다.
⇒ 이것이 바로 “모든 객체는 리렌더링 때 재생성되고, 참조가 다르다.” 라는 의미입니다.

**참조 동일성을 유지하지 못하는 것이 어떤 문제를 유발하나?**

과제를 진행하면서 memo, useMemo, useAutoCallback 훅을 작성한 코드를 보면 이해할 수 있습니다.

```jsx
// memo.ts

import { type FunctionComponent } from "react";
import { shallowEquals } from "../equals";
import { useRef } from "../hooks";

// memo HOC는 컴포넌트의 props를 얕은 비교하여 불필요한 렌더링을 방지합니다.
export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals): FunctionComponent<P> {
  // 메모이제이션된 컴포넌트 생성
  const MemoizedComponent: FunctionComponent<P> = (props) => {
    // 1. 이전 props를 저장할 ref 생성
    const memoizedRef = useRef<{
      prevProps: P | null;
      rendered: ReturnType<FunctionComponent<P>> | null;
    }>({
      // 이전 props 저장
      prevProps: null,
      // 이전 JSX 저장
      rendered: null,
    });

    // 3. eqauls 함수를 사용하여 props 비교 - 새롭게 컴포넌트 렌더링X
    if (memoizedRef.current.prevProps !== null && equals(memoizedRef.current.prevProps, props)) {
      return memoizedRef.current.rendered!;
    }

    // 4. props가 변경된 경우에만 새로운 렌더링 수행
    memoizedRef.current.prevProps = props;
    memoizedRef.current.rendered = Component(props);

    return memoizedRef.current.rendered;
  };

  return MemoizedComponent;
}
```

memo는 props를 shallowEqual(얕은 비교)를 수행하고 다르면 리렌더링을 하고 같으면 리렌더링을 막습니다.
그런데 config 객체는 매번 새로 생성되므로 얕은 비교에서 false를 반환하고 리렌더링을 하게 됩니다.

결국엔 컴포넌트는 매번 리렌더링되고 memo의 효과는 없어집니다.
이러한 방식이 반복되고 구조가 비대해지다보면 불필요한 렌더링과 성능저하로 이어지겠죠.

**참조 동일성을 안정화하는 방법**

참조 동일성을 안정화하는 방법의 두 가지를 배웠습니다.

**첫 번째, useRef를 사용하는 것입니다.**
값이 변하지 않거나, 값이 바뀌어도 리렌더링을 유발하지 않아야 할 때 사용할 수 있습니다.
다만 객체, 함수, DOM 노드 등 “**값은 유지하지만 UI와 무관**”한 상태에만 사용해야 합니다. 이는 리액트 공식문서 useRef 사용 주의사항에도 볼 수 있습니다.

**두 번째, 모든 의존성 값들을 useMemo나 useCallback으로 감싸 안정화하는 것입니다.**
이번 과제의 ToastProvider를 이렇게 값을 안정화하여 사용했습니다.
createActions 함수를 매번 재실행하지 않고 useMemo를 사용하여 참조의 안정성을 확보했고,  hideAfter 함수 역시 hide에 의존한 메모이제이션을 해주어 일관된 참조를 보장하도록 구성했습니다.

```jsx
// ToastProvider.tsx

export const ToastProvider = memo(({ children }: PropsWithChildren) => {
  const [state, dispatch] = useReducer(toastReducer, initialState);
  const { show, hide } = useMemo(() => createActions(dispatch), [dispatch]);
  const visible = state.message !== "";

  const hideAfter = useMemo(() => debounce(hide, DEFAULT_DELAY), [hide]);

  const showWithHide = useAutoCallback((message: string, type: ToastType) => {
    show(message, type);
    hideAfter();
  });

  const commandValue = useMemo(() => ({ show: showWithHide, hide }), [showWithHide, hide]);
  const stateValue = useMemo(() => ({ message: state.message, type: state.type }), [state.message, state.type]);

  return (
    <ToastCommandContext.Provider value={commandValue}>
      <ToastStateContext.Provider value={stateValue}>
        {children}
        {visible && createPortal(<Toast />, document.body)}
      </ToastStateContext.Provider>
    </ToastCommandContext.Provider>
  );
});
```

이런 과정들을 통해서 얕은 비교에서 참조 동일성이 왜 중요한지를 이해하고, 리액트의 렌더링 원리에 대해서 더 깊게 이해할 수 있었습니다.

<!-- 예시
- 새로 학습한 개념
- 기존 지식의 재발견/심화
- 구현 과정에서의 기술적 도전과 해결
-->

### 자랑하고 싶은 코드
**얕은 비교 - 객체 순수 비교**

처음에는 객체 비교를 하기 위해서 아래와 같이 type으로 구분을 했습니다. 물론, 테스트는 통과했지만 사실 자바스크립트에서 typeof value === “object” 라는 문자열로 반환되는 경우는 생각보다 많습니다. 배열, function, null, new Date(), new RegExp(), document.body …

<img width="144" height="135" alt="image" src="https://github.com/user-attachments/assets/24bbb9c3-7fa7-4ee0-a6a1-62f2a256e220" />

```jsx
 if (a && b && typeof a === "object" && typeof b === "object" && !Array.isArray(a) && !Array.isArray(b)) {
    const keysA = Object.keys(a);
    const keysB = Object.keys(b);

    if (keysA.length !== keysB.length) return false;

    for (const key of keysA) {
      if (!keysB.includes(key) || (a as Record<string, unknown>)[key] !== (b as Record<string, unknown>)[key])
        return false;
    }

    return true;
  }
```

따라서 isObject 함수로 순수 객체일 경우를 한 번 판단하고, Object.keys()로 직접 가진 key만 추출을 하고, Object.prototype,hasOwnProperty.call()로 해당 객체가 직접 소유하고 있는지 다시 판단하는 로직으로 변경하여 객체 여부에 대한 엣지 케이스를 보완하고 정밀도를 높였습니다.

```jsx
const isObject = (val: unknown): val is Record<string, unknown> => {
    return typeof val === "object" && val !== null && !Array.isArray(val);
  };

  if (isObject(a) && isObject(b)) {
    const keysA = Object.keys(a);
    const keysB = Object.keys(b);

    if (keysA.length !== keysB.length) return false;

    for (const key of keysA) {
      if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
      if (a[key] !== b[key]) return false; // 얕은 비교
    }

    return true;
  }
```

**깊은비교 리팩토링**

deepEquals 함수를 작성할 때에는, shallowEquals에서 depth가 추가된 배열이나 객체일 경우에만 재귀적으로 모든 depth에 대한 탐색 및 비교가 필요했습니다. 따라서, shallowEquals 함수를 가져와 이 부분을 추가해 주었습니다.

```jsx
// 리팩토링 전
export const deepEquals = (a: unknown, b: unknown): boolean => {
  // 1. 기본 값 비교
  if (a === b || (Number.isNaN(a) && Number.isNaN(b))) return true;

  // 2. 배열 비교
  if (Array.isArray(a) && Array.isArray(b)) {
    // 배열의 length로 비교
    if (a.length !== b.length) return false;

    // 재귀적으로 모든 depth의 요소를 비교
    for (let i = 0; i < a.length; i++) {
      if (!deepEquals(a[i], b[i])) return false;
    }

    return true;
  }

  // 배열이 아닌데 한쪽만 배열이면 false
  if (Array.isArray(a) !== Array.isArray(b)) return false;

  // 3. 순수 객체 비교
  const isObject = (val: unknown): val is Record<string, unknown> => {
    return typeof val === "object" && val !== null && !Array.isArray(val);
  };

  if (isObject(a) && isObject(b)) {
    const keysA = Object.keys(a);
    const keysB = Object.keys(b);

    if (keysA.length !== keysB.length) return false;

    for (const key of keysA) {
      if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
      if (!deepEquals(a[key], b[key])) return false;
    }

    return true;
  }

  // 기본 타입인데 === 실패했으면 false
  return false;
};

```

작성하고 보니, 기존 비교는 shallowEquals 함수를 실행시켜 비교시키고 재귀적으로 탐색 및 비교가 필요한 요소들에 대해서만 deepEquals 함수로 깊은 비교를 실행시키도록 리팩토링하여 불필요한 코드를 shallowEquals 함수로 재활용하면서 가독성을 높였습니다.

```jsx
import { shallowEquals } from "./shallowEquals";

export const deepEquals = (a: unknown, b: unknown): boolean => {
  if (shallowEquals(a, b)) return true;

  // 배열인 경우 재귀 비교
  if (Array.isArray(a) && Array.isArray(b)) {
    if (a.length !== b.length) return false;
    for (let i = 0; i < a.length; i++) {
      if (!deepEquals(a[i], b[i])) return false;
    }
    return true;
  }

  const isObject = (val: unknown): val is Record<string, unknown> =>
    typeof val === "object" && val !== null && !Array.isArray(val);

  // 순수 객체 재귀 비교
  if (isObject(a) && isObject(b)) {
    const keysA = Object.keys(a);
    const keysB = Object.keys(b);
    if (keysA.length !== keysB.length) return false;

    for (const key of keysA) {
      if (!Object.prototype.hasOwnProperty.call(b, key)) return false;
      if (!deepEquals(a[key], b[key])) return false;
    }

    return true;
  }

  return false;
};


```
### 개선이 필요하다고 생각하는 코드

```
export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals): FunctionComponent<P> {
  // 메모이제이션된 컴포넌트 생성
  const MemoizedComponent: FunctionComponent<P> = (props) => {
    // 1. 이전 props를 저장할 ref 생성
    const memoizedRef = useRef<{
      prevProps: P | null;
      rendered: ReturnType<FunctionComponent<P>> | null;
    }>({
      // 이전 props 저장
      prevProps: null,
      // 이전 JSX 저장
      rendered: null,
    });

    // 3. eqauls 함수를 사용하여 props 비교 - 새롭게 컴포넌트 렌더링X
    if (memoizedRef.current.prevProps !== null && equals(memoizedRef.current.prevProps, props)) {
      return memoizedRef.current.rendered!;
    }

    // 4. props가 변경된 경우에만 새로운 렌더링 수행
    memoizedRef.current.prevProps = props;
    memoizedRef.current.rendered = Component(props);

    return memoizedRef.current.rendered;
  };

  return MemoizedComponent;
}
```

memo 컴포넌트에서 equals 함수를 사용하여 props를 비교할 때 "새롭게 컴포넌트 렌더링을 시키지 않는다." 라는 의도로 Component 함수를 호출하지 않고 return해버렸는데, 이렇게 Component(props)를 조건부로 호출하는 방식이 문제가 생길 수도 있겠다는 생각이 들었습니다.
예를 들어서, 아래와 같이 memo로 감싸진 컴포넌트를 사용할 때 내부에서 hooks를 사용하게 되면 equals를 통한 변경이 일어나지 않았음에도 Component(props) 함수를 생략해버리니 React의 hook 규칙 위반 가능성이 될 수 있을것 같습니다.
이 부분에 대한 개선이 필요해보입니다!

```
const MyComponent = memo(function MyComponent(props) {
  const [count, setCount] = useState(0);
  useEffect(() => {
    console.log("effect 실행됨");
  }, []);

  return <div>{count}</div>;
});
```

<!-- 예시
- 특히 만족스러운 구현
- 리팩토링이 필요한 부분
- 코드 설계 관련 고민과 결정
-->

### 학습 효과 분석

리액트의 렌더링 과정과 원리에 대해서 심층 깊게 이해한 시간이었습니다.
다만, 꽤 많은 내용을 학습했기 때문에 제 지식으로 온전히 습득하기 위한 과정을 다시 한번 스스로 거쳐야겠습니다.

리액트의 렌더링 과정과 원리에 대해서는 리액트의 공식문서와 도서, 문서 등으로 학습했고 면접과 같은 중요한 날 전에는 이를 달달 외우곤 했습니다. 
하지만, 직접 학습하고 구현해보니 자연스레 외워지게 되었습니다.
예를 들어서, 2주차 때 학습한 과제에서 React element의 object 속성을 이해할 때 type, props, children 값들의 정의를 글로 외우다 보니 항상 몇 일 지나면 까먹었는데
이번에 직접 object로 트랜스파일링 하는 과정을 겪고, DOM에 반영하는 과정을 겪다보니 자연스레 type, props, children 값이 필요한 이유와 의미에 대해서 이해할 수 있었습니다.
또 리액트의 렌더링은 “얕은 비교를 수행하며 가상 DOM은 변경된 사항만 DOM에 직접 반영한다” 라는 의미를 워딩으로 외우다보니, 막상 얕은 비교는 어떻게 이루어지는지 참조 동일성은 어떻게 유지해야하는지 내부 원리에 대해서 정확히 이해하지 못하고 있었습니다. 
자연스레 과제를 하면서 부족했던 부분을 확인하고 지식을 습득할 수 있었습니다.

결론은 직접 구현하면서 이해하는 과정이 있다보니 재미있게 학습할 수 있었고, 1~3주차의 과제를 통해서 리액트에 대한 깊은 이해를 더욱 할 수 있는 기반이 만들어진 것 같습니다.

<!-- 예시
- 가장 큰 배움이 있었던 부분
- 추가 학습이 필요한 영역
- 실무 적용 가능성
-->

### 과제 피드백

과제 학습을 수행하며 리액트와 자바스크립트에 대한 조금 더 많이 이해할 수 있게 되었고, 더 깊은 수준을 이해할 수 있는 중요한 디딤돌이 되었습니다.
또한, AI와 함께 과제를 수행하면서 빠르게 나의 코드를 구조화하고, 분석하고, 리팩토링을 할 수 있었습니다. 

다만 요구하는 특정 기능을 “정답”에 가까운 코드로 만드는 것은 과제를 수행함에 있어서 사람마다 큰 습득이나 변별력이 없겠다는 생각이 들었습니다.
AI로 빠르고 일원화된 정답을 제출하는데, 코드를 작성하기 위해 고민한 시간과 노력들 그리고 의도와 목적들을 모두 표현하는게 더 중요하겠다는 생각이 들었습니다.
그래서 과제로서 이런 문제를 해결하는데는 어렵겠지만 경험하고 해결한 사례, 배경, 고민한 흔적들을 나눌 수 있을만한 과제나 시간이 있으면 더 좋을 것 같습니다.

아직.. 구체적인 예시까지는 생각은 못 해봤습니다.. ㅎ

<!-- 예시
- 과제에서 모호하거나 애매했던 부분
- 과제에서 좋았던 부분
-->

## 학습 갈무리

### 리액트의 렌더링이 어떻게 이루어지는지 정리해주세요.

리액트의 렌더링 과정은 React Element 생성 → 가상 DOM 비교 (diffing) → 실제 DOM 반영 (commit) 세 가지 단계로 구성이됩니다.

**1. JSX → React Element 생성**
JSX는 React.createElement 호출로 변환되어 React Element라는 일반 Javascript 객체가 됩니다.

**2. Reconciliation (조정 단계)**
      이전 렌더링 결과와 새로운 React Element를 비교하여 업데이트해야 할 변경점만 계산하게 됩니다. 이때, 이 과정을 통해 성능을 높이고 불필요한 DOM 업데이트를 방지합니다.

    이때 2주차 때 구현한 updateElement와 비교하면 주요 규칙은 다음과 같은 것들이 있습니다.
    
    - 타입(type)이 다르면 업데이트
        - 예) ```<div> → <span>```
        - 이전 노드 제거 + 새로운 노드 추가
    - 타입이 같으면 속성만 비교
        - 예)) ```<div className=”a”> → <div className=”b”>```
        - DOM은 재사용되고, className만 업데이트
    - Key 기반 리스트 비교
        - key를 기준으로 요소 재사용 여부를 판단

**3. Commit Phase (실제 DOM 반영 단계)**
앞서 수집된 변경사항을 기반으로 실제 DOM을 조작합니다.

### 메모이제이션에 대한 나의 생각을 적어주세요.
메모이제이션에 대한 생각을 먼저 표현하기 전에, 배경이 되는 리액트의 렌더링에 대한 생각을 먼저 정리하겠습니다.

**리액트의 렌더링에 대한 나의 생각**

리액트의 렌더링은 단순하고 예측 가능하다는 점에서 탁월하지만, 렌더링마다 함수 전체가 재실행되고 객체, 함수, 배열 등 모든 참조가 새로 만들어진다는 구조적인 특성은 개발자가 깊이 고민하고 다루어야할 부분이라고 생각합니다.
그래서 저는 이 구조를 단점으로 보지 않는 대신 **변경을 감지하는 기준이 참조이기 때문에 개발자는 참조를 유지할 책임이 있다**고 생각합니다. 즉, 의미있는 리렌더링을 의도할 책임이 있다고 생각합니다.
그렇기 때문에 리액트의 렌더링 원리를 정확하게 이해하는 것은 **값의 참조를 안정화해서, 의미있는 UI의 변화**가 반영될 수 있는 것이라고 생각합니다.

**메모이제이션**

먼저, 메모이제이션이란 어떤 연산의 결과를 캐싱해 두었다가, 동일한 입력이 들어오면 재계산하지 않고 캐시된 결과를 재사용하는 최적화 기법입니다.리액트의 메모이제이션은 제가 앞서 설명한 리액트의 렌더링의 구조적 단점을 보완할 수 있는 중요한 기술입니다.

단, 앞서 제가 얘기한 “**리엑트의 렌더링 원리를 정확하게 이해한 상태에서 구현할 때**” 라는 전제가 붙습니다.
React.memo, useMemo, useCallback 등은 참조의 동일성을 기반으로 동작하기 때문에 참조의 동일성을 지켜주지 않으면 오히려 불필요한 리렌더링, 불필요한 실행, 성능 저하로 이어지기 때문입니다.

### 컨텍스트와 상태관리에 대한 나의 생각을 적어주세요.

**상태 관리란?**

상태(state)는 UI가 반응해야 하는 데이터의 현재 모습을 의미합니다. 이 상태를 언제, 어디서, 어떻게 관리할지를 결정하는 것이프론트엔드 앱 설계에서는 가장 중요한 결정 중 하나입니다.
현재 상태관리 라이브러리로는 Redux, Zustand, Recoil 등이 주류를 이루고 있으며 React의 상태관리는 컴포넌트 내부에서 useState를 다루는 것이 일상이 되었습니다.
하지만, 상태의 복잡도보다 더 중요한 것은 “**이 상태를 누가 알아야 하는가?**” 즉, **컨텍스트의 경계 설정**입니다.

**컨텍스트의 역할**

React의 Context는 컴포넌트 트리 어디에서든 데이터를 공급하고 구독할 수 있게 해줍니다.
그러나, Context 내부 상태가 자주 바뀌면 그 상태를 구독 중인 모든 컴포넌트가 불필요하게 렌더링이 발생됩니다. 따라서, 컨텍스트는 공유 상태의 목적으로 쓰는 것이 가장 적절하다고 생각합니다.

**공유 상태(Shared State)**

공유 상태란 둘 이상의 컴포넌트가 함께 사용하는 상태를 의미합니다. 
앱 전역에서 일관된 정보를 관리하는 전역 상태의 목적과는 다르게 특정 UI흐름이나 기능 내에서 여러 컴포넌트 간 데이터를 공유하고 싶을 때, 제한된 범위 내에서 데이터를 공유하고 싶을 때 사용하는데 목적이 있습니다.

**결론**

따라서 상태 관리의 목적을 이해하고 설계하는 것이 중요하다고 생각이 됩니다. 공유 상태가 필요할 때는 컨텍스트, 전역 상태가 필요할 때는 전역 상태를 고려하는 것이 장,단점과 목적에 따른 적절한 사용 방법이라고 생각합니다.

<!-- 예시
- 컨텍스트와 상태관리가 필요한 이유는 무엇일까?
- 컨텍스트와 상태관리를 사용하지 않으면 어떤 문제가 발생할까?
- 컨텍스트와 상태관리를 사용했을 때의 장점과 단점은 무엇일까?
- 컨텍스트와 상태관리를 사용하지 않고도 해결할 수 있는 방법은 무엇일까?
- 컨텍스트와 상태관리를 사용할 때 주의해야 할 점은 무엇일까?
-->

## 리뷰 받고 싶은 내용

1. 메모이제이션이 필요한 부분을 어떻게 평가하며 사용하고 계신지가 궁금합니다!
- 과제를 진행하며 메모이제이션을 위한 참조 동일성을 보장하는 구조를 만들다 보니 depth가 깊어지거나 공유 상태 구조가 복잡해질수록 가독성도 떨어지고, 캐시 관련 유지비용이 더 생길 것 같습니다. 리액트에서도 최적화에 의한 확실한 이점이 있는 경우에만 사용할 것으로 명시가 되어 있는데.. 현업에서는 적용하기 애매한 포인트들이 여럿 있었는데, 주로 코치님께서는 어떤 상황에서 메모이제이션이 필요한 상황이라고 판단하고 의사결정했는지 간단하게라도 경험을 들려주실 수 있을까요?

<!--
피드백 받고 싶은 내용을 구체적으로 남겨주세요
모호한 요청은 피드백을 남기기 어렵습니다.

참고링크: https://chatgpt.com/share/675b6129-515c-8001-ba72-39d0fa4c7b62

모호한 질문의 예시)
- 무엇을 질문해야 할지 몰라서 코치님이 보시기에 고쳐야할것들 전반적으로 피드백 부탁드립니다.
- 코드 스타일에 대한 피드백 부탁드립니다.
- 코드 구조에 대한 피드백 부탁드립니다.
- 개념적인 오류에 대한 피드백 부탁드립니다.
- 추가 구현이 필요한 부분에 대한 피드백 부탁드립니다.

구체적인 질문의 예시)
- 파일A의 함수B와 그 안의 변수명을 보면 직관성이 떨어지는 것 같습니다. 함수와 변수 이름을 더 명확하게 지을 방법에 대해 조언해 주실 수 있나요?
- 현재 파일 단위로 코드를 분리했지만, 이번 주차 발제를 기준으로 봤을 때 모듈화나 계층화에서 부족함이 있는 것 같습니다. 특히 A와 B 부분에서 모듈화를 더 진행할지 그대로 둘지 고민하였습니다. (...구체적인 고민 사항 적기...). 코치님의 의견이 궁금합니다.
- 옵저버 패턴을 사용해 상태 관리 로직을 구현해 보려 했습니다. 제가 구현한 코드가 옵저버 패턴에 맞게 잘 구성되었는지 검토해 주시고, 보완할 부분을 제안해 주실 수 있을까요?
- 컴포넌트 A를 테스트 할 때 B와의 의존성 때문에 테스트 코드를 작성하려다 포기했습니다. A와 B의 의존성을 낮추고 테스트 가능성을 높이는 구조 개선 방안이 있을까요?

과제에서 디테일한 피드백을 받기 위해선 여러분의 생각을 디테일하게 표현해주셔야 한답니다.

가령, "전반적으로 이 라우터 구조가 규모가 커졌을 때 유지보수나 기능 확장에 유리한지, 아니면 리팩토링이 필요할지 조언을 받고 싶습니다" 라는 질문이 있을 때, 답변드리기가 어려워요. 
이럴 때는 "기능 확장" 상황을 먼저 가정해봐야합니다. 테스트의 엣지케이스를 작성하는 것 처럼요! 그리고 그 상황에 대해 내가 작성한 코드가 이러저러한 이유 때문에 대응가능할 것 같은데 혹시 더 고려해야할 부분이 있을지를 물어보는거죠.

이건 코치에게 이야기할 때 뿐만 아니라 팀원에게 이야기할 때에도 동일해요. 여러분의 컨텍스트를 명확하게 전달하지 않으면 여러분과 이야기할 때 시간이 무척 오래 걸린답니다.

특히 멘토링 처럼 동기적으로 이루어지는 커뮤니케이션에서는 위와 같은 질문을 던져도, 상호 피드백으로 질문을 함께 만들어갈 수 있지만, 과제 피드백 처럼 비동기 방식 + 1회용 질문일 때에는 좋은 답변을 드리기가 어려운점 인지 부탁드립니다 ㅠㅠ
-->
