### PR TITLE
[4팀 이유진] Chapter 1-3. React, Beyond the Basics

### DIFF
--- a/packages/app/404.html
+++ b/packages/app/404.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>상품 쇼핑몰</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/src/styles.css">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: "#3b82f6",
+            secondary: "#6b7280"
+          }
+        }
+      }
+    };
+  </script>
+</head>
+<body class="bg-gray-50">
+<div id="root"></div>
+<script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/packages/app/src/components/toast/ToastProvider.tsx
+++ b/packages/app/src/components/toast/ToastProvider.tsx
@@ -1,52 +1,54 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, memo, type PropsWithChildren, useContext, useReducer } from "react";
+import { createContext, memo, type PropsWithChildren, useContext, useMemo, useReducer } from "react";
 import { createPortal } from "react-dom";
 import { Toast } from "./Toast";
 import { createActions, initialState, toastReducer, type ToastType } from "./toastReducer";
 import { debounce } from "../../utils";
+import { useAutoCallback } from "@hanghae-plus/lib";
 
 type ShowToast = (message: string, type: ToastType) => void;
 type Hide = () => void;
 
-const ToastContext = createContext<{
-  message: string;
-  type: ToastType;
+const ToastCommandContext = createContext<{
   show: ShowToast;
   hide: Hide;
 }>({
-  ...initialState,
   show: () => null,
   hide: () => null,
+});
+const ToastStateContext = createContext<{
+  message: string;
+  type: ToastType;
+}>({
+  ...initialState,
 });
 
 const DEFAULT_DELAY = 3000;
 
-const useToastContext = () => useContext(ToastContext);
-export const useToastCommand = () => {
-  const { show, hide } = useToastContext();
-  return { show, hide };
-};
-export const useToastState = () => {
-  const { message, type } = useToastContext();
-  return { message, type };
-};
+export const useToastCommand = () => useContext(ToastCommandContext);
+export const useToastState = () => useContext(ToastStateContext);
 
 export const ToastProvider = memo(({ children }: PropsWithChildren) => {
   const [state, dispatch] = useReducer(toastReducer, initialState);
-  const { show, hide } = createActions(dispatch);
   const visible = state.message !== "";
 
-  const hideAfter = debounce(hide, DEFAULT_DELAY);
+  const { show, hide } = useMemo(() => createActions(dispatch), [dispatch]);
+  const hideAfter = useMemo(() => debounce(hide, DEFAULT_DELAY), [hide]);
 
-  const showWithHide: ShowToast = (...args) => {
+  const showWithHide: ShowToast = useAutoCallback((...args) => {
     show(...args);
     hideAfter();
-  };
+  });
+
+  const commandContextValue = useMemo(() => ({ show: showWithHide, hide }), [showWithHide, hide]);
+  const stateContextValue = useMemo(() => ({ message: state.message, type: state.type }), [state.message, state.type]);
 
   return (
-    <ToastContext value={{ show: showWithHide, hide, ...state }}>
-      {children}
-      {visible && createPortal(<Toast />, document.body)}
-    </ToastContext>
+    <ToastCommandContext.Provider value={commandContextValue}>
+      <ToastStateContext.Provider value={stateContextValue}>
+        {children}
+        {visible && createPortal(<Toast />, document.body)}
+      </ToastStateContext.Provider>
+    </ToastCommandContext.Provider>
   );
 });

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -1,3 +1,4 @@
+// main.tsx
 import { App } from "./App";
 import { router } from "./router";
 import { BASE_URL } from "./constants.ts";

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -12,6 +12,8 @@ export const createObserver = () => {
     listeners.delete(fn);
   };
 
+)
+
   const notify = () => listeners.forEach((listener) => listener());
 
   return { subscribe, notify };

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -6,13 +6,12 @@ export const createObserver = () => {
   // useSyncExternalStore 에서 활용할 수 있도록 subscribe 함수를 수정합니다.
   const subscribe = (fn: Listener) => {
     listeners.add(fn);
+    return () => unsubscribe(fn);
   };
 
   const unsubscribe = (fn: Listener) => {
     listeners.delete(fn);
   };
-
-)
 
   const notify = () => listeners.forEach((listener) => listener());
 

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,3 +1,32 @@
-export const deepEquals = (a: unknown, b: unknown) => {
-  return a === b;
-};
+export function deepEquals(objA: unknown, objB: unknown): boolean {
+  // 1. 기본 타입인 경우
+  if (typeof objA !== "object" || typeof objB !== "object") {
+    return objA === objB;
+  }
+
+  // null 인 경우
+  if (objA === null || objB === null) {
+    return objA === objB;
+  }
+
+  // 둘다 객체인 경우
+  // 배열인지 확인
+  if (Array.isArray(objA) && Array.isArray(objB)) {
+    if (objA.length !== objB.length) return false;
+    for (let i = 0; i < objA.length; i++) {
+      if (!deepEquals(objA[i], objB[i])) return false;
+    }
+    return true;
+  }
+
+  // 객체의 키 개수가 다른 경우
+  const aKeys = Object.keys(objA);
+  const bKeys = Object.keys(objB);
+  if (aKeys.length !== bKeys.length) return false;
+
+  // 재귀적으로 각 속성에 대해 deepEquals 호출
+  for (const key of aKeys) {
+    if (!deepEquals((objA as Record<string, unknown>)[key], (objB as Record<string, unknown>)[key])) return false;
+  }
+  return true;
+}

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -7,7 +7,7 @@ export const shallowEquals = (a: unknown, b: unknown) => {
     return false;
   }
 
-  // null cjfl
+  // null 처리
   if (a === null || b === null) return a === b;
 
   // 3. 객체의 키 개수가 다른 경우 처리

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,3 +1,26 @@
 export const shallowEquals = (a: unknown, b: unknown) => {
-  return a === b;
+  // 1. 두 값이 정확히 같은지 확인 (참조가 같은 경우)
+  if (a === b) return true;
+
+  // 2. 둘 중 하나라도 객체가 아닌 경우 처리
+  if (typeof a !== "object" || typeof b !== "object") {
+    return false;
+  }
+
+  // null cjfl
+  if (a === null || b === null) return a === b;
+
+  // 3. 객체의 키 개수가 다른 경우 처리
+  // 여기 도착하면 a,b는 object 타입이고 null이 아님
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+
+  // 4. 모든 키에 대해 얕은 비교 수행
+  for (const key of aKeys) {
+    if ((a as Record<string, unknown>)[key] !== (b as Record<string, unknown>)[key]) {
+      return false;
+    }
+  }
+  return true;
 };

--- a/packages/lib/src/hocs/deepMemo.ts
+++ b/packages/lib/src/hocs/deepMemo.ts
@@ -1,5 +1,7 @@
 import type { FunctionComponent } from "react";
+import { memo } from "./memo";
+import { deepEquals } from "../equals";
 
 export function deepMemo<P extends object>(Component: FunctionComponent<P>) {
-  return Component;
+  return memo(Component, deepEquals);
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -1,6 +1,30 @@
 import { type FunctionComponent } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "../hooks";
 
+// memo HOC는 컴포넌트의 props를 얕은 비교하여 불필요한 리렌더링을 방지합니다.
 export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
-  return Component;
+  const MemoizedComponent = (props: P): ReturnType<typeof Component> => {
+    // 1. 이전 props와 이전 렌더 결과를 저장할 ref 생성
+    const prevPropsRef = useRef<P | undefined>(undefined);
+    const prevResultRef = useRef<ReturnType<typeof Component> | undefined>(undefined);
+
+    // 2. 이전 props 가져오기
+    const prevProps = prevPropsRef.current;
+
+    // 3. equals 함수를 사용하여 props 비교
+    // 첫 렌더링이거나 props가 변경된 경우에만 새로 렌더링
+    const shouldRender = prevProps === undefined || !equals(prevProps, props);
+
+    // 4. props가 변경된 경우에만 새로운 렌더링 수행
+    if (shouldRender) {
+      prevPropsRef.current = props;
+      prevResultRef.current = Component(props);
+    }
+
+    // 5. 메모이제이션된 결과 반환
+    return prevResultRef.current!;
+  };
+
+  return MemoizedComponent;
 }

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -1,6 +1,6 @@
 import type { AnyFunction } from "../types";
-import { useCallback } from "./useCallback";
-import { useRef } from "./useRef";
+// import { useCallback } from "./useCallback";
+// import { useRef } from "./useRef";
 
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
   return fn;

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -2,13 +2,7 @@ import type { AnyFunction } from "../types";
 import { useCallback } from "./useCallback";
 import { useRef } from "./useRef";
 
-/**
- * 콜백함수가 **참조하는 값은 항상 렌더링 시점에 최신화** 되어야 한다.
- *  이 부분을 어떻게 해결할 수 있을지 고민해보세요!
- * 대신 항상 **동일한 참조를 유지**해야 한다 (useCallback 활용)
- */
 // useCallback과 useRef를 이용하여 useAutoCallback
-
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
   const fnRef = useRef<T>(fn);
   fnRef.current = fn;

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -1,7 +1,22 @@
 import type { AnyFunction } from "../types";
-// import { useCallback } from "./useCallback";
-// import { useRef } from "./useRef";
+import { useCallback } from "./useCallback";
+import { useRef } from "./useRef";
+
+/**
+ * 콜백함수가 **참조하는 값은 항상 렌더링 시점에 최신화** 되어야 한다.
+ *  이 부분을 어떻게 해결할 수 있을지 고민해보세요!
+ * 대신 항상 **동일한 참조를 유지**해야 한다 (useCallback 활용)
+ */
+// useCallback과 useRef를 이용하여 useAutoCallback
 
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
-  return fn;
+  const fnRef = useRef<T>(fn);
+  fnRef.current = fn;
+
+  // 의존성 배열이 빈배열이어서 항상 동일한 참조 유지
+  const callback = useCallback((...args: Parameters<T>): ReturnType<T> => {
+    return fnRef.current(...args); // 함수를 실행하면 됨
+  }, []);
+
+  return callback as T;
 };

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,7 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import type { DependencyList } from "react";
+import { useMemo } from "./useMemo";
 
 export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
-  // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => factory, _deps);
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -1,8 +1,24 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import type { DependencyList } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "./useRef";
 
 export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+  // 직접 작성한 useRef를 통해서 만들어보세요! 이게 제일 중요합니다.
+
+  // 1. 이전 의존성과 결과를 저장할 ref 생성
+  // undefined는 첫 렌더
+  // resultRef는 factory()의 실행결과 저장
+  const depsRef = useRef<DependencyList | undefined>(undefined);
+  const resultRef = useRef<T | undefined>(undefined);
+
+  // 2. 현재 의존성과 이전 의존성 비교
+  // 초기 렌더링이거나, 이전 의존성과 현재 의존성이 다르면 새로 메모이제이션 -> factory() 실행
+  // 3. 의존성이 변경된 경우 factory 함수 실행 및 결과 저장
+  if (depsRef.current === undefined || !_equals(depsRef.current, _deps)) {
+    depsRef.current = _deps;
+    resultRef.current = factory();
+  }
+
+  // 4. 메모이제이션된 값 반환
+  return resultRef.current as T;
 }

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,4 +1,8 @@
+import { useState } from "react";
+
 export function useRef<T>(initialValue: T): { current: T } {
   // useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  const [ref] = useState(() => ({ current: initialValue }));
+  console.log("ref", ref);
+  return ref;
 }

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,8 +1,9 @@
 import { useState } from "react";
 
 export function useRef<T>(initialValue: T): { current: T } {
-  // useState를 이용해서 만들어보세요.
+  // 리렌더링을 발생시키지 않는 이유: useState는 초기화 시에만 객체를 생성하고 이후 리렌더링에서는 동일한 객체 참조를 반환한다,
+  // useState의 setter를 호출하지 않는 한 리렌더링이 발생하지 않는다.
+  // React는 객체 내부 프로퍼티 변화(current의 변화)를 감지하지 못한다 (얕은 비교!)
   const [ref] = useState(() => ({ current: initialValue }));
-  console.log("ref", ref);
   return ref;
 }

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -1,6 +1,6 @@
 import type { RouterInstance } from "../Router";
 import type { AnyFunction } from "../types";
-import { useSyncExternalStore } from "react";
+// import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
 
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -1,6 +1,6 @@
 import type { RouterInstance } from "../Router";
 import type { AnyFunction } from "../types";
-// import { useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
 
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
@@ -8,5 +8,5 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 export const useRouter = <T extends RouterInstance<AnyFunction>, S>(router: T, selector = defaultSelector<T, S>) => {
   // useSyncExternalStore를 사용하여 router의 상태를 구독하고 가져오는 훅을 구현합니다.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(router);
+  return useSyncExternalStore(router.subscribe, () => shallowSelector(router));
 };

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -1,5 +1,5 @@
-import { useRef } from "react";
-import { shallowEquals } from "../equals";
+// import { useRef } from "react";
+// import { shallowEquals } from "../equals";
 
 type Selector<T, S = T> = (state: T) => S;
 

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -5,7 +5,7 @@ type Selector<T, S = T> = (state: T) => S;
 
 export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
   // 이전 상태를 저장하고, shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
-  const prevStateRef = useRef<T | undefined>(undefined);
+  const prevStateRef = useRef<S | undefined>(undefined);
 
   return (state: T): S => {
     const selected = selector(state);

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -1,9 +1,18 @@
-// import { useRef } from "react";
-// import { shallowEquals } from "../equals";
+import { useRef } from "react";
+import { shallowEquals } from "../equals";
 
 type Selector<T, S = T> = (state: T) => S;
 
 export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
   // 이전 상태를 저장하고, shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
-  return (state: T): S => selector(state);
+  const prevStateRef = useRef<T | undefined>(undefined);
+
+  return (state: T): S => {
+    const selected = selector(state);
+    if (prevStateRef.current === undefined || !shallowEquals(prevStateRef.current, selected)) {
+      prevStateRef.current = selected;
+    }
+
+    return prevStateRef.current;
+  };
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,8 +1,17 @@
 import { useState } from "react";
-// import { shallowEquals } from "../equals";
+import { shallowEquals } from "../equals";
+import { useCallback } from "react";
 
-export const useShallowState = () => {
-  // export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
+export const useShallowState = <T>(initialValue: T | (() => T)) => {
   // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
-  return useState();
+  const [state, setState] = useState<T>(initialValue);
+
+  const setShallowState = useCallback((value: T) => {
+    setState((prevState: T) => {
+      // prevState는 항상 최신 상태값을 참조합니다
+      return shallowEquals(prevState, value) ? prevState : value;
+    });
+  }, []);
+
+  return [state, setShallowState] as const;
 };

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { shallowEquals } from "../equals";
+// import { shallowEquals } from "../equals";
 
-export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
+export const useShallowState = () => {
+  // export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
   // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
-  return useState(initialValue);
+  return useState();
 };

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+// import { useSyncExternalStore } from "react";
 import type { createStorage } from "../createStorage";
 
 type Storage<T> = ReturnType<typeof createStorage<T>>;

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -1,9 +1,9 @@
-// import { useSyncExternalStore } from "react";
+import { useSyncExternalStore } from "react";
 import type { createStorage } from "../createStorage";
 
 type Storage<T> = ReturnType<typeof createStorage<T>>;
 
 export const useStorage = <T>(storage: Storage<T>) => {
   // useSyncExternalStore를 사용해서 storage의 상태를 구독하고 가져오는 훅을 구현해보세요.
-  return storage.get();
+  return useSyncExternalStore(storage.subscribe, storage.get);
 };

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -9,5 +9,5 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 export const useStore = <T, S = T>(store: Store<T>, selector: (state: T) => S = defaultSelector<T, S>) => {
   // useSyncExternalStore와 useShallowSelector를 사용해서 store의 상태를 구독하고 가져오는 훅을 구현해보세요.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(store.getState());
+  return useSyncExternalStore(store.subscribe, () => shallowSelector(store.getState()));
 };


### PR DESCRIPTION
## 과제 체크포인트

### 배포 링크
https://elli-lee.github.io/front_6th_chapter1-3/

### 기본과제

#### equalities

- [x] shallowEquals 구현 완료
- [x] deepEquals 구현 완료

#### hooks

- [x] useRef 구현 완료
- [x] useMemo 구현 완료
- [x] useCallback 구현 완료
- [x] useDeepMemo 구현 완료
- [x] useShallowState 구현 완료
- [x] useAutoCallback 구현 완료

#### High Order Components

- [x] memo 구현 완료
- [x] deepMemo 구현 완료

### 심화 과제

#### hooks

- [x] createObserver를 useSyncExternalStore에 사용하기 적합한 코드로 개선
- [x] useShallowSelector 구현
- [x] useStore 구현
- [x] useRouter 구현
- [x] useStorage 구현

### context

- [x] ToastContext, ModalContext 개선

## 과제 셀프회고
 이번 과제가 1주차 세번의 과제 중 정답과 방향이 가장 명확해서 비교적 수월했기 때문에, 왜 이렇게 동작하도록 함수를 작성해야 하는지를 명확히 이해하고자 노력했고, 각 함수에서 처리해야할 로직들을 AI 도움을 최소화해서 구현하려고 노력했습니다 .리액트의 여러 훅들을 직접 구현하면서 훅들의 동작 원리를 알 수 있었고, 리액트가 무엇을 해결하고자 했는지가 조금씩 느껴졌습니다.
3주간 프레임워크 없이 SPA 만들기를 진행하면서 SPA 프레임워크의 동작 원리를 어느정도 알고있다고 생각했는데 알고있기는 커녕 저는 여태껏 궁금해 한 적 조차 없었다는 사실을 깨달았고, 자바스크립트 실력이 많이 부족하다는 것도 느꼈습니다. 
저의 부족함을 많이 알게된 3주였고, 제 과제의 결과물이 제 스스로도 만족할 만큼의 수준은 아니지만(특히 1주차 과제..시간되는대로 꼭 다시 도전해보고 싶어요..), 3주간의 몰입이 돌아보니 정말 재밌었고, 개인적으로는 많이 성장했다고 생각합니다!

### 기술적 성장
** Equalities 구현 과정에서 **
어떤 타입을 먼저 처리해야 하는지, 각 분기 처리를 거칠 때마다 어떤 타입으로 좁혀지는지, 잘못 처리된 타입은 없는지 신경쓰며 구현했습니다.
이 과정에서 typeof null은 object라는 사실을 처음 알게 되어 object 타입을 처리하기 전 null을 먼저 처리해주었습니다.

** useRef 구현 과정에서 **
어떻게 내부적으로 useState를 사용하는데 리렌더링을 발생시키지 않을 수 있을지 이해하는데 시간이 걸렸습니다.

useState는 초기화 시에만 객체를 생성하고 이후 리렌더링에서는 동일한 객체 참조를 반환하고, useState의 setter를 호출하지 않는 한 리렌더링이 발생하지 않는다.
React는 객체 내부 프로퍼티 변화(current의 변화)를 감지하지 못한다 (얕은 비교!)
는 점을 알게 되었습니다.

useState의 구조분해 할당으로 state만 받고 setter 함수는 아예 안받는 이유가 궁금했는데, setter가 리렌더링을 유발하기 때문에 useRef에서는 필요없어서 안 받았다는 아주아주 당연한 사실도 새삼 알게 되었습니다..
또한, 테스트 코드를 통해 useRef가 수행해야하는 결과를 이해하고자 노력했는데, 중복을 걸러주는 Set 자료구조를 사용해서 Set의 size를 통해 리렌더링 시 참조가 변했는지를 체크하는 점이 인상깊었습니다.

** useMemo 구현 과정에서 **
useMemo를 구현하면서 궁금했던 부분은 왜 deps를 깊은비교가 아닌 얕은 비교로 수행하는지 였습니다.
찾아본 결과, 
깊은 비교는 비용이 너무 크다!
만약 deps를 깊은 비교(deep equality)로 검사하려면:
배열의 각 요소가 객체일 경우 그 안의 속성까지 전부 비교해야 하는데, 이건 성능 비용이 크고, 특히 렌더링마다 비교하게 되면 전체 앱의 성능이 떨어질 수 있기 때문임을 알게 되었습니다.

** useCallback 구현 과정에서 **
리액트를 제대로 사용해본 적이 없는 저는... React.memo로도 충분할것 같은데 왜 useCallback이 필요한지 궁금했습니다.
핵심은 함수도 결국 객체이기 때문에 그 함수를 가지고 있는 부모컴포넌트가 리렌더 될 때마다 다시 생성된 새 함수가 되어 참조값이 달라지기 때문이었습니다.
자식 컴포넌트에 memo가 적용되어 있어도, 부모 컴포넌트가 자식 컴포넌트에게 함수를 전달하고 있는 경우, 부모컴포넌트가 리렌더링 될 때마다 함수의 참조값이 바뀌므로 자식컴포넌트는 props가 바뀌었다고 판단하기 때문에 memo와 관계없이 리렌더링되기 때문임을 알게 되었습니다.

### 자랑하고 싶은 코드
자랑할 만한 코드를 찾는것... 정말 어려운 일입니다..🥹
그나마 찾아보자면..
코드적으로 자랑하고 싶다기 보다는.. 
useMemo의 동작을 이해하기 위해 오래 고민하고 공부하고 스스로 구현했다는 점에서 당첨되었습니다.

```
export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {

  // 1. 이전 의존성과 결과를 저장할 ref 생성
  // undefined는 첫 렌더
  // resultRef는 factory()의 실행결과 저장
  const depsRef = useRef<DependencyList | undefined>(undefined);
  const resultRef = useRef<T | undefined>(undefined);

  // 2. 현재 의존성과 이전 의존성 비교
  // 초기 렌더링이거나, 이전 의존성과 현재 의존성이 다르면 새로 메모이제이션 -> factory() 실행
  // 3. 의존성이 변경된 경우 factory 함수 실행 및 결과 저장
  if (depsRef.current === undefined || !_equals(depsRef.current, _deps)) {
    depsRef.current = _deps;
    resultRef.current = factory();
  }

  // 4. 메모이제이션된 값 반환
  return resultRef.current as T;
}

```
### 개선이 필요하다고 생각하는 코드
deepEquals에서
```
  // 둘다 객체인 경우
  // 배열인지 확인
  if (Array.isArray(objA) && Array.isArray(objB)) {
    if (objA.length !== objB.length) return false;
    for (let i = 0; i < objA.length; i++) {
      if (!deepEquals(objA[i], objB[i])) return false;
    }
    return true;
  }
```
객체 처리할 때 배열을 먼저 별도로 처리했는데요,
구현할 때는 배열을 별도로 분기처리 안했더니 테스트코드를 통과하지 못해서 분기처리를 했었는데,,
과연 정말 필요한 분기 처리였을까, 분기처리의 문제가 아니라 기존 로직 자체에 문제가 있었을 수도 있겠다하는 생각이 듭니다.

### 학습 효과 분석
** 가장 큰 배움이 있었던 부분 **
React의 렌더링 최적화 메커니즘을 이해하게 되었습니다. 특히 의존성 배열의 비교 방식과 메모이제이션의 실제 동작 원리를 알 수 있었습니다.

** 추가 학습이 필요한 영역 **
복잡한 타입스크립트 이슈가 발생하면 타입 단언으로 처리하거나 타입 오류를 해결해달라고 AI에게 요청..해서 해결했는데, 이에 대한 추가적인 학습이 필요할 것 같습니다. 
개인적으로는 과제를 다 진행하고 나니, 실무에서 사용하고 있는 Vue의 동작 원리와 내부 구현도 궁금해졌습니다.  

### 과제 피드백
앞에서 구현한 함수를 그 다음 함수를 구현하는데 사용하도록 설계되어 왜 이렇게 동작해야 하는지를 명확히 이해할 수 있어서 좋았습니다. 또한 실제 React 내부 구현과 유사한 방식으로 설계되어 리액트 deep dive 경험을 할 수 있어서 좋았습니다.

## 학습 갈무리

### 리액트의 렌더링이 어떻게 이루어지는지 정리해주세요.
리액트의 렌더링 과정: 
리액트는 상태(state)나 props가 변경되었을 때 컴포넌트를 다시 렌더링합니다.
- 트리거 > setState 혹은 부모 컴포넌트로부터 전달받은 props가 변경되면 해당 컴포넌트가 다시 렌더링됩니다.
- 렌더 > JSX를 기반으로 새로운 Virtual DOM을 생성합니다.이 과정은 순수 함수처럼 작동하며, 화면에 아무것도 그리지 않습니다.
- 조정 (Reconciliation) > diff 알고리즘을 사용해서 이전 Virtual DOM과 새로운 Virtual DOM을 비교하여 변경점을 찾습니다.
- 커밋 > 변경된 부분만 실제 브라우저 DOM에 적용합니다.

리액트의 렌더링 최적화 방법:
- useMemo > 무거운 연산 결과를 캐싱해서, 의존성이 변경되지 않으면 다시 계산하지 않습니다.
- useCallback > 함수를 메모이제이션하여, 불필요하게 새로운 함수 인스턴스를 생성하지 않도록 합니다. 자식 컴포넌트에 함수를 props로 넘길 때 유용합니다.
- React.memo > 컴포넌트를 메모이제이션하여, props가 바뀌지 않으면 리렌더링하지 않도록 합니다.


### 메모이제이션에 대한 나의 생각을 적어주세요.
메모이제이션이 필요한 경우:
- 비용이 큰 계산이 반복될 때 > 예를 들어, 무거운 연산을 수행하는 함수가 렌더링마다 실행된다면 useMemo를 사용해 계산을 캐싱할 수 있습니다.
- 자식 컴포넌트의 불필요한 리렌더링을 방지할 때 > React.memo를 통해 props가 변경되지 않았을 때 자식 컴포넌트의 리렌더링을 막을 수 있습니다.

장점: 
- 성능 최적화 > 불필요한 계산, 불필요한 컴포넌트 렌더링을 방지할 수 있습니다.
- 예측 가능한 렌더링 > 의존성 배열을 명시함으로써, 어떤 조건에서 계산이 다시 수행되는지 명확해집니다.
 
단점: 
- 메모리 사용량 증가 > 캐시된 값을 메모리에 보관하므로, 리소스를 추가로 사용하게 됩니다.
- 복잡성 증가 > 로직을 분석할 때 메모이제이션된 값을 따로 추적해야 하는 경우가 생깁니다.

제가 생각하는 사용법:
- 성능 문제가 실제로 발생했을 때 적용하기...? 
   useMemo는 언제 사용하면 좋을지 조금 감이 오는 것 같은데, React.memo는 언제 적용해야 할지 판단이 어렵습니다...
- 만약 메모이제이션을 사용한다면 의존성 배열을 정확히 관리할 것


### 컨텍스트와 상태관리에 대한 나의 생각을 적어주세요.
컨텍스트와 상태관리가 필요한 이유:
- React는 기본적으로 단방향 데이터 흐름을 갖기 때문에, 상위 컴포넌트에서 하위 컴포넌트로 props를 계속 전달해야 합니다. 여러 컴포넌트에서 공통으로 사용하는 전역 상태가 생겼을 때 Context API나 상태 관리 라이브러리를 통해 상태를 전역으로 공유할 수 있습니다.

컨텍스트와 상태관리를 사용하지 않으면 발생하는 문제:
- Prop drilling: 중간에 쓰지도 않는 컴포넌트들이 props를 전달만 하게 됩니다
- 상태의 일관성 문제: 여러 컴포넌트가 동일한 데이터를 따로따로 관리하면 서로 동기화가 되지 않아 UI가 일관되지 않게 됩니다.

사용했을 때의 장점:
- 전역적으로 상태를 공유할 수 있음: 여러 컴포넌트에서 동일한 상태를 쉽게 참조하고 수정할 수 있습니다.
- 구조가 간결해짐: 중간 단계 컴포넌트에서 props를 전달할 필요가 없어지고, 로직이 분리되어 코드가 더 깔끔해집니다.

사용했을 때의 단점:
- 렌더링 성능 이슈: Context의 값이 바뀌면 해당 컨텍스트를 구독하고 있는 모든 컴포넌트가 리렌더링됩니다.
- 남용 시: 모든 상태를 Context로 관리하면, 흐름 추적이 어려워지고 디버깅이 힘들 수 있습니다.

사용 시 주의할 점:
- 진짜 전역 상태만 Context로 관리할 것: 예를 들어 다크모드 설정이나 로그인 정보처럼 앱 전반에 영향을 주는 상태만 Context로 사용하는 것이 좋습니다.

## 리뷰 받고 싶은 내용
1. 동작에는 아무런 차이가 없겠지만, useMemo에서 의존성 배열에 대한 depsRef와 factory 실행 결과를 저장하는 resultRef를 하나의 객체로 두는게 더 좋은 구조일지에 대한 고민을 했습니다.
저는 
```
  const depsRef = useRef<DependencyList | undefined>(undefined);
  const resultRef = useRef<T | undefined>(undefined);
```
이렇게 별도로 두긴 했는데요, (이유는.. 객체로 다루는 것이 비교 등등에서 신경 쓸 포인트가 늘어날 수도 있겠다...는 생각이었습니다)

``` 
	const memoRef =  useRef<{ deps: DependencyList | undefined; result: T | undefined }>({
    deps: undefined, // 이전 의존성
    result: undefined, // 결과
  });
```
이렇게 하나의 객체로 두는 것이 더 나은 구조인지, 코치님께서는 어떤 방식을 선호하시는지 궁금합니다.

2. 타입스크립트가 최대한 알아서 추론하게 두고, 타입 단언은 지양해라! 라는 내용을 늘 생각하면서 개발하고자 하는데요,
과제 구현 과정에서 타입 이슈 해결을 위해서 타입 단언을 사용한 부분이 꽤 있습니다.
이 중에서 특히 useMemo의 return 에서 한 타입 단언이 안전한지 궁금합니다.