### PR TITLE
[3팀 장루빈] Chapter 1-3. 프레임워크 없이 SPA 만들기

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,6 @@
     "prepare": "husky",
     "gh-pages": "pnpm -F @hanghae-plus/shopping build && gh-pages -d ./packages/app/dist"
   },
-  "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
-      "prettier --write"
-    ]
-  },
   "devDependencies": {
     "@babel/core": "latest",
     "@babel/plugin-transform-react-jsx": "latest",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
     "prepare": "husky",
     "gh-pages": "pnpm -F @hanghae-plus/shopping build && gh-pages -d ./packages/app/dist"
   },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "prettier --write"
+    ]
+  },
   "devDependencies": {
     "@babel/core": "latest",
     "@babel/plugin-transform-react-jsx": "latest",

--- a/packages/app/src/components/toast/ToastProvider.tsx
+++ b/packages/app/src/components/toast/ToastProvider.tsx
@@ -1,52 +1,52 @@
 /* eslint-disable react-refresh/only-export-components */
-import { createContext, memo, type PropsWithChildren, useContext, useReducer } from "react";
+import { createContext, memo, type PropsWithChildren, useCallback, useContext, useMemo, useReducer } from "react";
 import { createPortal } from "react-dom";
+import { debounce } from "../../utils";
 import { Toast } from "./Toast";
 import { createActions, initialState, toastReducer, type ToastType } from "./toastReducer";
-import { debounce } from "../../utils";
 
 type ShowToast = (message: string, type: ToastType) => void;
 type Hide = () => void;
 
-const ToastContext = createContext<{
-  message: string;
-  type: ToastType;
-  show: ShowToast;
-  hide: Hide;
-}>({
-  ...initialState,
+const ToastStateContext = createContext(initialState);
+const ToastCommandContext = createContext<{ show: ShowToast; hide: Hide }>({
   show: () => null,
   hide: () => null,
 });
 
 const DEFAULT_DELAY = 3000;
 
-const useToastContext = () => useContext(ToastContext);
-export const useToastCommand = () => {
-  const { show, hide } = useToastContext();
-  return { show, hide };
-};
+const useToastCommandContext = () => useContext(ToastCommandContext);
+const useToastStateContext = () => useContext(ToastStateContext);
+
+export const useToastCommand = () => useToastCommandContext();
 export const useToastState = () => {
-  const { message, type } = useToastContext();
+  const { message, type } = useToastStateContext();
   return { message, type };
 };
 
 export const ToastProvider = memo(({ children }: PropsWithChildren) => {
   const [state, dispatch] = useReducer(toastReducer, initialState);
-  const { show, hide } = createActions(dispatch);
+  const { show, hide } = useMemo(() => createActions(dispatch), [dispatch]);
   const visible = state.message !== "";
+  const hideAfter = useMemo(() => debounce(hide, DEFAULT_DELAY), [hide]);
 
-  const hideAfter = debounce(hide, DEFAULT_DELAY);
+  const showWithHide = useCallback<ShowToast>(
+    (...args) => {
+      show(...args);
+      hideAfter();
+    },
+    [show, hideAfter],
+  );
 
-  const showWithHide: ShowToast = (...args) => {
-    show(...args);
-    hideAfter();
-  };
+  const commandValue = useMemo(() => ({ show: showWithHide, hide }), [showWithHide, hide]);
 
   return (
-    <ToastContext value={{ show: showWithHide, hide, ...state }}>
-      {children}
-      {visible && createPortal(<Toast />, document.body)}
-    </ToastContext>
+    <ToastCommandContext.Provider value={commandValue}>
+      <ToastStateContext.Provider value={state}>
+        {children}
+        {visible && createPortal(<Toast />, document.body)}
+      </ToastStateContext.Provider>
+    </ToastCommandContext.Provider>
   );
 });

--- a/packages/lib/src/createObserver.ts
+++ b/packages/lib/src/createObserver.ts
@@ -11,7 +11,7 @@ export const createObserver = () => {
   const unsubscribe = (fn: Listener) => {
     listeners.delete(fn);
   };
-
+  console.log(unsubscribe);
   const notify = () => listeners.forEach((listener) => listener());
 
   return { subscribe, notify };

--- a/packages/lib/src/equals/deepEquals.ts
+++ b/packages/lib/src/equals/deepEquals.ts
@@ -1,3 +1,22 @@
-export const deepEquals = (a: unknown, b: unknown) => {
-  return a === b;
+const isArray = (data: unknown): data is unknown[] => Array.isArray(data);
+
+const isObject = (data: unknown): data is Record<string, unknown> => typeof data === "object" && data !== null;
+
+export const deepEquals = (a: unknown, b: unknown): boolean => {
+  if (a === b) return true;
+
+  if (isArray(a) && isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEquals(v, b[i]));
+  }
+
+  if (isObject(a) && isObject(b)) {
+    const keysA = Object.keys(a);
+    const keysB = Object.keys(b);
+
+    if (keysA.length !== keysB.length) return false;
+    return keysA.every((key) => deepEquals(a[key], b[key]));
+  }
+
+  return false;
 };

--- a/packages/lib/src/equals/shallowEquals.ts
+++ b/packages/lib/src/equals/shallowEquals.ts
@@ -1,3 +1,33 @@
+const isArray = (data: unknown) => Array.isArray(data);
+
+const isObject = (data: unknown): data is Record<string, unknown> => typeof data === "object" && data !== null;
+
+const compareValue = (a: unknown, b: unknown) => a === b;
+
+const compareArray = (a: unknown[], b: unknown[]) => a.length === b.length && a.every((v, i) => v === b[i]);
+
+const compareKeys = (keysA: string[], keysB: string[]): boolean =>
+  keysA.length === keysB.length && keysA.every((key) => keysB.includes(key));
+
+const compareObject =
+  (a: Record<string, unknown>, b: Record<string, unknown>) =>
+  (keys: string[]): boolean =>
+    keys.every((key) => a[key] === b[key]);
+
+const compareObjects = (a: Record<string, unknown>, b: Record<string, unknown>): boolean => {
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+
+  return compareKeys(keysA, keysB) && compareObject(a, b)(keysA);
+};
+
 export const shallowEquals = (a: unknown, b: unknown) => {
-  return a === b;
+  if (compareValue(a, b)) return true;
+
+  if (isArray(a) && isArray(b)) {
+    return compareArray(a, b);
+  }
+
+  if (isObject(a) && isObject(b)) return compareObjects(a, b);
+  return false;
 };

--- a/packages/lib/src/hocs/deepMemo.ts
+++ b/packages/lib/src/hocs/deepMemo.ts
@@ -1,5 +1,15 @@
 import type { FunctionComponent } from "react";
-
+import { deepEquals } from "../equals";
 export function deepMemo<P extends object>(Component: FunctionComponent<P>) {
-  return Component;
+  let prevProps: P | null = null;
+  let prevResult: ReturnType<FunctionComponent<P>> | null = null;
+
+  return function MemoizedComponent(props: P) {
+    if (prevProps === null || !deepEquals(prevProps, props)) {
+      prevResult = Component(props);
+      prevProps = props;
+    }
+
+    return prevResult;
+  };
 }

--- a/packages/lib/src/hocs/memo.ts
+++ b/packages/lib/src/hocs/memo.ts
@@ -2,5 +2,15 @@ import { type FunctionComponent } from "react";
 import { shallowEquals } from "../equals";
 
 export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
-  return Component;
+  let prevProps: P | null = null;
+  let prevResult: ReturnType<FunctionComponent<P>> | null = null;
+
+  return function MemoizedComponent(props: P) {
+    if (prevProps === null || !equals(prevProps, props)) {
+      prevResult = Component(props);
+      prevProps = props;
+    }
+
+    return prevResult;
+  };
 }

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -1,7 +1,13 @@
 import type { AnyFunction } from "../types";
 import { useCallback } from "./useCallback";
 import { useRef } from "./useRef";
-
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
-  return fn;
+  const fnRef = useRef(fn);
+  // 갱신
+  fnRef.current = fn;
+  const stableFn = useCallback((...args: Parameters<T>) => {
+    return fnRef.current(...args);
+  }, []);
+
+  return stableFn as T;
 };

--- a/packages/lib/src/hooks/useAutoCallback.ts
+++ b/packages/lib/src/hooks/useAutoCallback.ts
@@ -3,10 +3,11 @@ import { useCallback } from "./useCallback";
 import { useRef } from "./useRef";
 export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
   const fnRef = useRef(fn);
-  // 갱신
+  // 갱신필요 => stale closure
   fnRef.current = fn;
   const stableFn = useCallback((...args: Parameters<T>) => {
     return fnRef.current(...args);
+    // 참조유지
   }, []);
 
   return stableFn as T;

--- a/packages/lib/src/hooks/useCallback.ts
+++ b/packages/lib/src/hooks/useCallback.ts
@@ -1,7 +1,8 @@
-/* eslint-disable @typescript-eslint/no-unused-vars,@typescript-eslint/no-unsafe-function-type */
+/* eslint-disable @typescript-eslint/no-unsafe-function-type */
 import type { DependencyList } from "react";
-
+import { useMemo } from "./useMemo";
 export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
-  // 직접 작성한 useMemo를 통해서 만들어보세요.
-  return factory as T;
+  // _deps는 리터럴 값이 아니며 factory를 의존성 배열에 추가해선 안됨
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => factory, _deps);
 }

--- a/packages/lib/src/hooks/useMemo.ts
+++ b/packages/lib/src/hooks/useMemo.ts
@@ -1,8 +1,16 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import type { DependencyList } from "react";
 import { shallowEquals } from "../equals";
+import { useRef } from "./useRef"; // 직접 만든 useRef 사용
 
-export function useMemo<T>(factory: () => T, _deps: DependencyList, _equals = shallowEquals): T {
-  // 직접 작성한 useRef를 통해서 만들어보세요.
-  return factory();
+export function useMemo<T>(factory: () => T, deps: DependencyList, equals = shallowEquals): T {
+  const ref = useRef<{ deps: DependencyList; value: T } | null>(null);
+
+  if (ref.current === null || !equals(ref.current.deps, deps)) {
+    ref.current = {
+      deps,
+      value: factory(),
+    };
+  }
+
+  return ref.current.value;
 }

--- a/packages/lib/src/hooks/useRef.ts
+++ b/packages/lib/src/hooks/useRef.ts
@@ -1,4 +1,5 @@
+import { useState } from "react";
 export function useRef<T>(initialValue: T): { current: T } {
-  // useState를 이용해서 만들어보세요.
-  return { current: initialValue };
+  const [ref] = useState<{ current: T }>({ current: initialValue });
+  return ref;
 }

--- a/packages/lib/src/hooks/useRouter.ts
+++ b/packages/lib/src/hooks/useRouter.ts
@@ -1,6 +1,6 @@
+import { useSyncExternalStore } from "react";
 import type { RouterInstance } from "../Router";
 import type { AnyFunction } from "../types";
-import { useSyncExternalStore } from "react";
 import { useShallowSelector } from "./useShallowSelector";
 
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
@@ -8,5 +8,5 @@ const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 export const useRouter = <T extends RouterInstance<AnyFunction>, S>(router: T, selector = defaultSelector<T, S>) => {
   // useSyncExternalStore를 사용하여 router의 상태를 구독하고 가져오는 훅을 구현합니다.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(router);
+  return useSyncExternalStore(router.subscribe, () => shallowSelector(router));
 };

--- a/packages/lib/src/hooks/useShallowSelector.ts
+++ b/packages/lib/src/hooks/useShallowSelector.ts
@@ -1,9 +1,14 @@
 import { useRef } from "react";
 import { shallowEquals } from "../equals";
 
-type Selector<T, S = T> = (state: T) => S;
+export function useShallowSelector<T, S>(selector: (state: T) => S): (state: T) => S {
+  const prevResultRef = useRef<S | undefined>(undefined);
 
-export const useShallowSelector = <T, S = T>(selector: Selector<T, S>) => {
-  // 이전 상태를 저장하고, shallowEquals를 사용하여 상태가 변경되었는지 확인하는 훅을 구현합니다.
-  return (state: T): S => selector(state);
-};
+  const shallowSelector = (state: T): S => {
+    const result = selector(state);
+    if (!shallowEquals(prevResultRef.current, result)) prevResultRef.current = result;
+    return prevResultRef.current as S;
+  };
+
+  return shallowSelector;
+}

--- a/packages/lib/src/hooks/useShallowState.ts
+++ b/packages/lib/src/hooks/useShallowState.ts
@@ -1,7 +1,15 @@
 import { useState } from "react";
 import { shallowEquals } from "../equals";
+import { useCallback } from "./useCallback";
+// initialValue타입 명시적으로 선언
+export const useShallowState = <T>(initialValue: T | (() => T)) => {
+  const [state, setState] = useState<T>(initialValue);
+  // setShallowState는 호출마다 새로정의 되기 때문에 메모이제이션
+  const setShallowState = useCallback((nextState: T) => {
+    setState((prev) => {
+      return shallowEquals(prev, nextState) ? prev : nextState;
+    });
+  }, []);
 
-export const useShallowState = <T>(initialValue: Parameters<typeof useState<T>>[0]) => {
-  // useState를 사용하여 상태를 관리하고, shallowEquals를 사용하여 상태 변경을 감지하는 훅을 구현합니다.
-  return useState(initialValue);
+  return [state, setShallowState] as const;
 };

--- a/packages/lib/src/hooks/useStorage.ts
+++ b/packages/lib/src/hooks/useStorage.ts
@@ -3,7 +3,8 @@ import type { createStorage } from "../createStorage";
 
 type Storage<T> = ReturnType<typeof createStorage<T>>;
 
+// localStorage persist한 상태관리 라이브러리처럼, 스토리지 상태를 동기화 하기 위해 useSyncExternalStore를 사용
 export const useStorage = <T>(storage: Storage<T>) => {
-  // useSyncExternalStore를 사용해서 storage의 상태를 구독하고 가져오는 훅을 구현해보세요.
-  return storage.get();
+  return useSyncExternalStore(storage.subscribe, storage.get);
 };
+// 외부 상태 저장소 변화감지?

--- a/packages/lib/src/hooks/useStore.ts
+++ b/packages/lib/src/hooks/useStore.ts
@@ -1,5 +1,5 @@
-import type { createStore } from "../createStore";
 import { useSyncExternalStore } from "react";
+import type { createStore } from "../createStore";
 import { useShallowSelector } from "./useShallowSelector";
 
 type Store<T> = ReturnType<typeof createStore<T>>;
@@ -7,7 +7,7 @@ type Store<T> = ReturnType<typeof createStore<T>>;
 const defaultSelector = <T, S = T>(state: T) => state as unknown as S;
 
 export const useStore = <T, S = T>(store: Store<T>, selector: (state: T) => S = defaultSelector<T, S>) => {
-  // useSyncExternalStore와 useShallowSelector를 사용해서 store의 상태를 구독하고 가져오는 훅을 구현해보세요.
   const shallowSelector = useShallowSelector(selector);
-  return shallowSelector(store.getState());
+  //  selector 함수 자체가 아닌 state반환
+  return useSyncExternalStore(store.subscribe, () => shallowSelector(store.getState()));
 };


### PR DESCRIPTION
## 과제 체크포인트

### 배포 링크

https://jangrubin2.github.io/front_6th_chapter1-3/

### 기본과제

#### equalities

- [x] shallowEquals 구현 완료
- [x] deepEquals 구현 완료

#### hooks

- [x] useRef 구현 완료
- [x] useMemo 구현 완료
- [x] useCallback 구현 완료
- [x] useDeepMemo 구현 완료
- [x] useShallowState 구현 완료
- [x] useAutoCallback 구현 완료

#### High Order Components

- [x] memo 구현 완료
- [x] deepMemo 구현 완료

### 심화 과제

#### hooks

- [x] createObserver를 useSyncExternalStore에 사용하기 적합한 코드로 개선
- [x] useShallowSelector 구현
- [x] useStore 구현
- [x] useRouter 구현
- [x] useStorage 구현

### context

- [x] ToastContext, ModalContext 개선

## 과제 셀프회고

<!-- 과제에 대한 회고를 작성해주세요 -->

### 기술적 성장
1. ShallowEqual
참조 무결성 유지 목적
React의 memo, useMemo, useEffect, useCallback 등에서는 참조 변경 여부로 re-render 판단함
얕은 비교로도 대부분의 상태 변경 감지 목적에는 충분

2. DeepEquals
상태 비교 / 동기화 여부 판단
프론트엔드 상태 관리(예: Redux, Zustand)에서 이전 상태와 다음 상태가 완전히 같은지 확인할 때.
재귀적으로 호출하여 값을 비교

3. useRef
```ts
import { useState } from "react";
export function useRef<T>(initialValue: T): { current: T } {
  const [ref] = useState<{ current: T }>({ current: initialValue });
or
 const [ref] = useState(() => ({ current: initialValue }));

  return ref;
}
```
useState의 lazy(지연) or eager(즉시) initialization  + 불변성 유지를 통해 useRef구현
useState(() => init())는 초기 렌더링 시 한 번만 init() 함수를 호출하여 초기값을 설정하고,
useState(init())는 매 렌더링마다 init()이 평가되지만 처음 값만 사용합니다.

복잡한 초기화 로직이 있다면 useState(() => init()) 방식이 더 효율적

4. useMemo 
```ts
export function useMemo<T>(factory: () => T, deps: DependencyList, equals = shallowEquals): T {
  const ref = useRef<{ deps: DependencyList; value: T } | null>(null);

  if (ref.current === null || !equals(ref.current.deps, deps)) {
    ref.current = {
      deps,
      value: factory(),
    };
  }

  return ref.current.value;
}
```
deps가 변경되지 않으면 factory()를 다시 호출하지 않고, 기존 값을 재사용
dependency array (의존성 배열)과 함수를 ref에 캐싱하고 캐시 무효화 조건문을 거쳐
기존 값 혹은 새로운 값을 반환하게 했습니다.

5. useCallback
```ts
export function useCallback<T extends Function>(factory: T, _deps: DependencyList) {
  // eslint-disable-next-line react-hooks/exhaustive-deps
  return useMemo(() => factory, _deps);
}
```
useCallback(fn, deps)은 deps가 바뀌지 않는 한 fn의 참조를 유지해야합니다.
기존에 만든 useMemo 훅을 이용해 메모이제이션하고 참조값이 바뀔 때만 함수를 다시 선언하게합니다.

여기서 _deps에 아래 에러가 생기게 되는데
```ts
React Hook useMemo was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies.eslint[react-hooks/exhaustive-deps](https://github.com/facebook/react/issues/14920)
React Hook useMemo has a missing dependency: 'factory'. Either include it or remove the dependency array.eslint[react-hooks/exhaustive-deps](https://github.com/facebook/react/issues/14920)
```
이것은 _deps가 리터럴 값이 아니어서 deps 안에 무엇이 들어있는지 정적으로 분석할 수 없고
콜백 안에서 사용하는 factory가 의존성 배열에 없다는 뜻인데 의존성 배열에 factory를 넣으면 의미 없는 캐싱이 되기 때문에 주석을 추가했습니다.

6. useShallowState
```ts
export const useShallowState = <T>(initialValue: T | (() => T)) => {
  const [state, setState] = useState<T>(initialValue);
  // setShallowState는 호출마다 새로정의 되기 때문에 메모이제이션
  const setShallowState = useCallback((nextState: T) => {
    setState((prev) => {
      return shallowEquals(prev, nextState) ? prev : nextState;
    });
  }, []);

  return [state, setShallowState] as const;
};
```
react에서 useState는 새로운 값이 Object.is(prev, next) 비교 결과 다르면 무조건 리렌더링을 발생시킵니다.
useShallowState는 내부적으로 shallowEquals를 사용하여 객체나 배열도 값만 같다면 상태를 변경하지 않고 리렌더링을 막습니다.

얕은 비교는 객체 참조까지만 비교하므로 내부 객체가 새로 만들어지면 리렌더링이 발생합니다.

7. useDeepMemo
```ts
export function useDeepMemo<T>(factory: () => T, deps: DependencyList): T {
  return useMemo(factory, deps, deepEquals);
}
```
React의 기본 useMemo는 deps 배열을 얕은 비교 (shallow equality) 로 비교합니다.
깊은 비교(deep equality)를 사용해 값이 같으면 재계산 방지

8. useAutoCallback
```ts
export const useAutoCallback = <T extends AnyFunction>(fn: T): T => {
  const fnRef = useRef(fn);
  // 갱신필요 => stale closure
  fnRef.current = fn;
  const stableFn = useCallback((...args: Parameters<T>) => {
    return fnRef.current(...args);
    // 참조유지
  }, []);

  return stableFn as T;
};

```
참조는 고정되지만 내부 로직은 항상 최신 상태인 콜백 함수
fn이 최신값일 수 있으므로 매 렌더마다 갱신함.
이렇게 하지 않으면 fnRef.current는 오래된 함수(초기값) 를 참조하게 됨 → stale closure 발생.
https://javascript.plainenglish.io/stale-closures-in-react-afb0dda37f0b

참조는 유지하되 내용은 항상 최신으로 갱신하는 것이 핵심 코드.
useCallback의 deps가 []이므로 stableFn은 렌더링 간 절대로 바뀌지 않음

9. memo
얕은 비교를 기반으로 리렌더링을 방지하는 고차 컴포넌트(HOC)
prevProps와 prevResult를 클로저에 저장하여 비교 및 캐싱 수행
```ts
export function memo<P extends object>(Component: FunctionComponent<P>, equals = shallowEquals) {
  let prevProps: P | null = null;
  let prevResult: ReturnType<FunctionComponent<P>> | null = null;

  return function MemoizedComponent(props: P) {
    if (prevProps === null || !equals(prevProps, props)) {
      prevResult = Component(props);
      prevProps = props;
    }

    return prevResult;
  };
}
```

10. deepMemo
컴포넌트 렌더링 결과를 deep equality로 캐싱하는 고차 컴포넌트(HOC)
객체 안에 중첩된 속성이 있어 React.memo의 얕은 비교로는 리렌더링 방지가 어려운 경우에 사용합니다.
```ts
export function deepMemo<P extends object>(Component: FunctionComponent<P>) {
  let prevProps: P | null = null;
  let prevResult: ReturnType<FunctionComponent<P>> | null = null;

  return function MemoizedComponent(props: P) {
    if (prevProps === null || !deepEquals(prevProps, props)) {
      prevResult = Component(props);
      prevProps = props;
    }

    return prevResult;
  };
}
```
deepEquals(prevProps, props)를 통해 이전 프롭과 새 프롭을 깊은 비교
동일한 경우 캐시된 렌더링 결과 prevResult를 반환하여 리렌더링 방지
최초 렌더링이거나 프롭이 달라졌을 때만 실제 컴포넌트를 실행
### 학습 효과 분석

<!-- 예시
- 가장 큰 배움이 있었던 부분
- 추가 학습이 필요한 영역
- 실무 적용 가능성
-->
직접 리액트훅을 만들어서 내부적으로 어떻게 동작하는지 알 수 있게 된 것이 가장 큰 러닝포인트였고,
제네릭 타입의 활용에대한 학습이 필요할 듯합니다.
실무에서는 커스텀 훅을 직접 만들 일이 없지만 내부적으로 어떻게 동작하는지 이해했으니 좀 더 적절한 때에 사용할 수 있지 않을까라는
생각이 듭니다.
### 과제 피드백
이번 과제는 AI를 적극적으로 사용했습니다. 또 다른 분들의 pr을 보면서 참고한 내용이 많았는데 남의 코드를 보는 것에
익숙해져야겠다고 느꼈습니다. 좋은 레퍼런스가 많네요

## 학습 갈무리

### 리액트의 렌더링이 어떻게 이루어지는지 정리해주세요.
1.  상태 변경 or props 변경 발생
2. 해당 컴포넌트의 함수 다시 실행 (Function Component 재호출)
3. 이전 Virtual DOM과 새로운 Virtual DOM을 비교
4. 변경된 부분만 실제 DOM에 반영

### 메모이제이션에 대한 나의 생각을 적어주세요.
동일한 입력에 대해 계산 결과를 캐싱하여 불필요한 계산을 줄이고 렌더링 최적화
메모이제이션을 하지 않으면 매 렌더링마다 함수나 값이 새로 생성되어 참조가 달라짐
useEffect, React.memo 등에서 불필요한 리렌더링/재실행 발생
무거운 연산이 매번 다시 계산되어 성능 저하

### 컨텍스트와 상태관리에 대한 나의 생각을 적어주세요.
컴포넌트 간 데이터 공유와 상태 동기화를 효율적으로 하기 위함
컨텍스트를 사용하지 않으면 상태를 props로 계속 전달해야 함 (prop drilling)
컴포넌트가 많아질수록 코드 복잡도가 상승할 것이고 상태의 출처와 흐름을 추적하기 어려워질 것입니다.

## 리뷰 받고 싶은 내용
1. 이런 과제를 수행한다면 코치님은 AI를 어떻게 활용할 것인지 궁금합니다.
2. 이번 과제는 완료하는 것을 목표로 했습니다. 과정을 완벽하게 이해하지 않고 넘어간 부분도 있으나 pr을 작성하면서 재학습하는 식으로 진행했는데요
정리한 내용중에 모호하거나 본질적인 내용과 거리가 있다면 그것이 궁금합니다!
